### PR TITLE
[#68] Remove java 1.8 from build_and_release

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -10,11 +10,8 @@ jobs:
     name: Build and release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdk 21
         targetSdk 32
         versionCode 1
-        versionName "1.0"
+        versionName "0.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
Closes #68 

## What happened 👀

Release workflow is failing when push to `develop`

## Insight 📝

Remove using `JAVA 1.8` from `build_and_release.yml` file

## Proof Of Work 📹

TBD
