### PR TITLE
[#20] Integrate survey detail screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,8 @@ plugins {
     id 'kotlin-kapt'
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
     id 'dagger.hilt.android.plugin'
+    id 'kotlin-android'
+    id 'kotlin-parcelize'
 }
 
 android {

--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreenTest.kt
@@ -15,6 +15,7 @@ import com.kks.nimblesurveyjetpackcompose.repo.home.HomeRepo
 import com.kks.nimblesurveyjetpackcompose.surveys
 import com.kks.nimblesurveyjetpackcompose.ui.theme.NimbleSurveyJetpackComposeTheme
 import com.kks.nimblesurveyjetpackcompose.viewmodel.home.HomeViewModel
+import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -84,7 +85,12 @@ class HomeScreenTest : BaseAndroidComposeTest() {
         every { homeRepo.fetchUserDetail() } returns flowOf(ResourceState.Loading)
         homeViewModel = HomeViewModel(homeRepo = homeRepo, ioDispatcher = Dispatchers.IO)
         composeTestRule.activity.setContent {
-            NimbleSurveyJetpackComposeTheme { HomeScreen(viewModel = homeViewModel) }
+            NimbleSurveyJetpackComposeTheme {
+                HomeScreen(
+                    viewModel = homeViewModel,
+                    navigator = EmptyDestinationsNavigator
+                )
+            }
         }
     }
 }

--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyHomeDetailScreenKtTest.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyHomeDetailScreenKtTest.kt
@@ -11,7 +11,6 @@ import com.kks.nimblesurveyjetpackcompose.model.Survey
 import com.kks.nimblesurveyjetpackcompose.surveys
 import com.kks.nimblesurveyjetpackcompose.ui.theme.NimbleSurveyJetpackComposeTheme
 import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
-import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import com.kks.nimblesurveyjetpackcompose.R
@@ -53,7 +52,7 @@ class SurveyHomeDetailScreenKtTest : BaseAndroidComposeTest() {
     private fun setupSurveyHomeDetailScreen(survey: Survey) {
         composeTestRule.activity.setContent {
             NimbleSurveyJetpackComposeTheme {
-                SurveyHomeDetailScreen(navigator = EmptyDestinationsNavigator, survey = survey)
+                SurveyDetailScreen(navigator = EmptyDestinationsNavigator, survey = survey)
             }
         }
     }

--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyHomeDetailScreenKtTest.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyHomeDetailScreenKtTest.kt
@@ -1,0 +1,60 @@
+package com.kks.nimblesurveyjetpackcompose.ui.presentation.survey
+
+import androidx.activity.compose.setContent
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.kks.nimblesurveyjetpackcompose.base.BaseAndroidComposeTest
+import com.kks.nimblesurveyjetpackcompose.model.Survey
+import com.kks.nimblesurveyjetpackcompose.surveys
+import com.kks.nimblesurveyjetpackcompose.ui.theme.NimbleSurveyJetpackComposeTheme
+import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import com.kks.nimblesurveyjetpackcompose.R
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Rule
+
+@HiltAndroidTest
+class SurveyHomeDetailScreenKtTest : BaseAndroidComposeTest() {
+
+    @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        setupSurveyHomeDetailScreen(surveys.first())
+    }
+
+    @Test
+    fun when_navigate_to_survey_home_detail_screen_show_survey_detail() {
+        with(composeTestRule) {
+            onNodeWithText(surveys.first().title).assertIsDisplayed()
+            onNodeWithText(surveys.first().description).assertIsDisplayed()
+            onNodeWithContentDescription(getString(R.string.survey_detail_back_icon)).assertIsDisplayed()
+            onNodeWithContentDescription(getString(R.string.survey_detail_start_survey)).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun when_click_on_start_survey_button_the_button_disappeared() {
+        with(composeTestRule) {
+            onNodeWithContentDescription(getString(R.string.survey_detail_start_survey)).performClick()
+            waitForIdle()
+            onNodeWithContentDescription(getString(R.string.survey_detail_start_survey)).assertIsNotDisplayed()
+        }
+    }
+
+    private fun setupSurveyHomeDetailScreen(survey: Survey) {
+        composeTestRule.activity.setContent {
+            NimbleSurveyJetpackComposeTheme {
+                SurveyHomeDetailScreen(navigator = EmptyDestinationsNavigator, survey = survey)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/Survey.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/Survey.kt
@@ -1,7 +1,9 @@
 package com.kks.nimblesurveyjetpackcompose.model
 
 import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class Survey(
     val id: String,
     val coverImagePlaceholderUrl: String,

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/Survey.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/Survey.kt
@@ -1,11 +1,13 @@
 package com.kks.nimblesurveyjetpackcompose.model
 
+import android.os.Parcelable
+
 data class Survey(
     val id: String,
     val coverImagePlaceholderUrl: String,
     val title: String,
     val description: String
-) {
+) : Parcelable {
     val coverImageFullUrl: String
         get() = "${coverImagePlaceholderUrl}l"
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
@@ -40,6 +40,7 @@ import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.model.Survey
 import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.DotsIndicator
 import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.ErrorAlertDialog
+import com.kks.nimblesurveyjetpackcompose.ui.presentation.destinations.SurveyHomeDetailScreenDestination
 import com.kks.nimblesurveyjetpackcompose.ui.theme.NeuzeitFamily
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White20
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White70
@@ -47,6 +48,8 @@ import com.kks.nimblesurveyjetpackcompose.util.DateUtil
 import com.kks.nimblesurveyjetpackcompose.util.TWEEN_ANIM_TIME
 import com.kks.nimblesurveyjetpackcompose.viewmodel.home.HomeViewModel
 import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
 
 private const val FRACTION = 0.3f
 private const val IDLE = 0
@@ -62,7 +65,7 @@ private const val MID_STATE = "M"
 @OptIn(ExperimentalMaterialApi::class)
 @Destination
 @Composable
-fun HomeScreen(viewModel: HomeViewModel = hiltViewModel()) {
+fun HomeScreen(navigator: DestinationsNavigator, viewModel: HomeViewModel = hiltViewModel()) {
     val activity = LocalContext.current as? Activity
 
     val surveyList by viewModel.surveyList.collectAsState()
@@ -126,7 +129,8 @@ fun HomeScreen(viewModel: HomeViewModel = hiltViewModel()) {
                         numberOfPage = surveyList.size,
                         selectedSurveyNumber = selectedSurveyNumber,
                         survey = surveyList[selectedSurveyNumber],
-                        userAvatar = userAvatar
+                        userAvatar = userAvatar,
+                        navigator = navigator
                     )
                 }
             }
@@ -157,6 +161,7 @@ fun SurveyContent(
     survey: Survey,
     numberOfPage: Int,
     selectedSurveyNumber: Int,
+    navigator: DestinationsNavigator,
     modifier: Modifier,
     userAvatar: String?
 ) {
@@ -205,7 +210,8 @@ fun SurveyContent(
                 .constrainAs(bottomView) { bottom.linkTo(parent.bottom, 54.dp) },
             numberOfPage = numberOfPage,
             currentPage = selectedSurveyNumber,
-            survey = survey
+            survey = survey,
+            navigator = navigator
         )
     }
 }
@@ -246,6 +252,7 @@ fun BottomView(
     survey: Survey,
     numberOfPage: Int,
     currentPage: Int,
+    navigator: DestinationsNavigator,
     modifier: Modifier
 ) {
     Column(modifier = modifier) {
@@ -281,7 +288,7 @@ fun BottomView(
                     }
             )
             Button(
-                onClick = { },
+                onClick = { navigator.navigate(SurveyHomeDetailScreenDestination(survey = survey)) },
                 modifier = Modifier
                     .clip(CircleShape)
                     .size(56.dp)
@@ -330,5 +337,5 @@ fun SurveyText(
 @Preview(showBackground = true)
 @Composable
 fun HomeContentPreview() {
-    HomeScreen()
+    HomeScreen(EmptyDestinationsNavigator)
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
@@ -40,7 +40,7 @@ import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.model.Survey
 import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.DotsIndicator
 import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.ErrorAlertDialog
-import com.kks.nimblesurveyjetpackcompose.ui.presentation.destinations.SurveyHomeDetailScreenDestination
+import com.kks.nimblesurveyjetpackcompose.ui.presentation.destinations.SurveyDetailScreenDestination
 import com.kks.nimblesurveyjetpackcompose.ui.theme.NeuzeitFamily
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White20
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White70
@@ -288,7 +288,7 @@ fun BottomView(
                     }
             )
             Button(
-                onClick = { navigator.navigate(SurveyHomeDetailScreenDestination(survey = survey)) },
+                onClick = { navigator.navigate(SurveyDetailScreenDestination(survey = survey)) },
                 modifier = Modifier
                     .clip(CircleShape)
                     .size(56.dp)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/splash/SplashScreen.kt
@@ -89,9 +89,7 @@ fun SplashScreen(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        BackgroundImage(
-            isBlurred = showLoginComponents
-        )
+        BackgroundImage(isBlurred = showLoginComponents)
         LogoImage(
             modifier = Modifier
                 .size(201.0.dp, 48.0.dp)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
-import coil.compose.rememberAsyncImagePainter
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.kks.nimblesurveyjetpackcompose.R

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -25,11 +26,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import coil.compose.rememberAsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
@@ -40,12 +44,15 @@ import com.kks.nimblesurveyjetpackcompose.ui.theme.NeuzeitFamily
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White70
 import com.kks.nimblesurveyjetpackcompose.util.TWEEN_ANIM_TIME
 import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
 
 @OptIn(ExperimentalPagerApi::class)
 @Destination
 @Composable
-fun SurveyDetailScreen(survey: Survey) {
+fun SurveyDetailScreen(navigator: DestinationsNavigator, survey: Survey) {
     var currentPage by remember { mutableStateOf(0) }
+    val startSurveyDescription = stringResource(id = R.string.survey_detail_start_survey)
     val placeholderPainter = rememberAsyncImagePainter(model = survey.coverImagePlaceholderUrl)
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -73,6 +80,7 @@ fun SurveyDetailScreen(survey: Survey) {
             }
         }
         SurveyToolbar(
+            navigator = navigator,
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.TopCenter)
@@ -85,6 +93,7 @@ fun SurveyDetailScreen(survey: Survey) {
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(bottom = 54.dp, end = 20.dp)
+                .semantics { contentDescription = startSurveyDescription }
         )
     }
 }
@@ -143,21 +152,31 @@ fun SurveyDetailStartScreen(survey: Survey, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun SurveyToolbar(modifier: Modifier, showBack: Boolean, showClose: Boolean) {
+fun SurveyToolbar(navigator: DestinationsNavigator, modifier: Modifier, showBack: Boolean, showClose: Boolean) {
     Box(modifier = modifier) {
         if (showBack) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_back_accent),
-                contentDescription = stringResource(id = R.string.survey_detail_back_icon),
+            IconButton(
+                onClick = { navigator.popBackStack() },
                 modifier = Modifier.align(Alignment.CenterStart)
-            )
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_back_accent),
+                    contentDescription = stringResource(id = R.string.survey_detail_back_icon)
+                )
+            }
         }
         if (showClose) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_close_button_white),
-                contentDescription = stringResource(id = R.string.survey_detail_close_icon),
+            IconButton(
+                onClick = {
+                    // TODO: Implement dialog to confirm close
+                },
                 modifier = Modifier.align(Alignment.CenterEnd)
-            )
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_close_button_white),
+                    contentDescription = stringResource(id = R.string.survey_detail_close_icon),
+                )
+            }
         }
     }
 }
@@ -166,7 +185,8 @@ fun SurveyToolbar(modifier: Modifier, showBack: Boolean, showClose: Boolean) {
 @Composable
 fun SurveyHomeDetailScreenPreview() {
     SurveyDetailScreen(
-        Survey(
+        navigator = EmptyDestinationsNavigator,
+        survey = Survey(
             id = "",
             coverImagePlaceholderUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/c96c480fc8b69d50e75a_",
             title = "Tree Tops Australia",

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -51,7 +51,6 @@ import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
 @Composable
 fun SurveyDetailScreen(navigator: DestinationsNavigator, survey: Survey) {
     var currentPage by remember { mutableStateOf(0) }
-    val startSurveyDescription = stringResource(id = R.string.survey_detail_start_survey)
     val placeholderPainter = rememberAsyncImagePainter(model = survey.coverImagePlaceholderUrl)
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -92,7 +91,6 @@ fun SurveyDetailScreen(navigator: DestinationsNavigator, survey: Survey) {
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(bottom = 54.dp, end = 20.dp)
-                .semantics { contentDescription = startSurveyDescription }
         )
     }
 }
@@ -100,11 +98,12 @@ fun SurveyDetailScreen(navigator: DestinationsNavigator, survey: Survey) {
 @Composable
 fun StartSurveyBtn(onStartSurvey: () -> Unit, modifier: Modifier = Modifier) {
     var showStartSurveyBtn by remember { mutableStateOf(true) }
+    val startSurveyDescription = stringResource(id = R.string.survey_detail_start_survey)
 
     Crossfade(
         targetState = showStartSurveyBtn,
         animationSpec = tween(TWEEN_ANIM_TIME),
-        modifier = modifier
+        modifier = modifier.semantics { contentDescription = startSurveyDescription }
     ) {
         if (it) {
             Button(


### PR DESCRIPTION
Closes #20 

## What happened 👀

Before taking a survey, users should be able to see the full preview of the details so that they can decide whether or not the survey matching their expectation.
- Upon tapping the Survey Disclosure button in Home, navigate the user to Survey Details with the selected survey.
- Pass and use the selected survey data fetched in Home.
- Use the survey title as the Title label
- Use the survey description as the Description label
- Use the survey cover image url as the background image

## Insight 📝

- Pass the selected survey to survey detail
- Implement survey detail test

## Proof Of Work 📹


https://user-images.githubusercontent.com/32578035/187836818-738eb9a2-d8d6-411a-8507-c702242529c4.mp4


