### PR TITLE
[#78] Fix home screen not maintaining index

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
@@ -33,6 +33,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
+import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
@@ -167,7 +168,7 @@ fun SurveyContent(
 
     ConstraintLayout(modifier = modifier.semantics { contentDescription = surveyContentDescription }) {
         val (date, userImage, bottomView) = createRefs()
-        SurveyImage(imageUrl = survey.coverImagePlaceholderUrl)
+        SurveyImage(imageUrl = survey.coverImageFullUrl, placeholderUrl = survey.coverImagePlaceholderUrl)
         Image(
             painter = painterResource(id = R.drawable.survey_overlay),
             contentDescription = null,
@@ -215,7 +216,9 @@ fun SurveyContent(
 }
 
 @Composable
-fun SurveyImage(imageUrl: String) {
+fun SurveyImage(imageUrl: String, placeholderUrl: String) {
+    val placeholderPainter = rememberAsyncImagePainter(model = placeholderUrl)
+
     Crossfade(
         targetState = imageUrl,
         animationSpec = tween(TWEEN_ANIM_TIME)
@@ -225,7 +228,7 @@ fun SurveyImage(imageUrl: String) {
                 .data(it)
                 .crossfade(true)
                 .build(),
-            placeholder = painterResource(R.drawable.ic_launcher_foreground),
+            placeholder = placeholderPainter,
             contentDescription = stringResource(id = R.string.home_survey_background_image),
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Crop

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
@@ -55,7 +55,6 @@ private const val FRACTION = 0.3f
 private const val IDLE = 0
 private const val LEFT_SWIPE = 1
 private const val RIGHT_SWIPE = -1
-private const val START_SURVEY_NUMBER = 0
 private const val START_ANCHOR = 0f
 private const val LEFT_STATE = "L"
 private const val RIGHT_STATE = "R"
@@ -70,7 +69,7 @@ fun HomeScreen(navigator: DestinationsNavigator, viewModel: HomeViewModel = hilt
 
     val surveyList by viewModel.surveyList.collectAsState()
     val error by viewModel.error.collectAsState()
-    var selectedSurveyNumber by remember { mutableStateOf(START_SURVEY_NUMBER) }
+    val selectedSurveyNumber by viewModel.selectedSurveyNumber.collectAsState()
     val swipeableState = rememberSwipeableState(initialValue = MID_STATE)
     val endAnchor = LocalDensity.current.run { LocalConfiguration.current.screenWidthDp.toDp().toPx() }
     // Maps anchor points (in px) to states
@@ -83,7 +82,6 @@ fun HomeScreen(navigator: DestinationsNavigator, viewModel: HomeViewModel = hilt
         state = rememberSwipeRefreshState(isRefreshing),
         onRefresh = {
             viewModel.clearCacheAndFetch()
-            selectedSurveyNumber = START_SURVEY_NUMBER
         },
         modifier = Modifier.fillMaxSize()
     ) {
@@ -109,7 +107,7 @@ fun HomeScreen(navigator: DestinationsNavigator, viewModel: HomeViewModel = hilt
                                     (selectedSurveyNumber < surveyList.size - 1 && threshold == LEFT_SWIPE) ||
                                     (selectedSurveyNumber != 0 && threshold == RIGHT_SWIPE)
                                 ) {
-                                    selectedSurveyNumber += threshold
+                                    viewModel.setSelectedSurveyNumber(selectedSurveyNumber + threshold)
                                     if (selectedSurveyNumber == (surveyList.size) - 2) viewModel.getNextPage()
                                 }
                                 threshold = IDLE

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModel.kt
@@ -19,6 +19,7 @@ import javax.inject.Inject
 const val DEFAULT_PAGE_SIZE = 5
 const val DEFAULT_NUMBER_OF_PAGE = 1
 const val DEFAULT_CURRENT_PAGE = 1
+private const val START_SURVEY_NUMBER = 0
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
@@ -32,12 +33,16 @@ class HomeViewModel @Inject constructor(
     private val _currentPageNumber = MutableStateFlow(DEFAULT_CURRENT_PAGE)
     private val _userAvatar = MutableStateFlow<String?>(null)
     private var totalNumberOfPage = DEFAULT_NUMBER_OF_PAGE
+    private val _selectedSurveyNumber = MutableStateFlow(START_SURVEY_NUMBER)
 
     init {
         getUserDetail()
         getSurveyListFromDb()
         getSurveyList()
     }
+
+    val selectedSurveyNumber: StateFlow<Int>
+        get() = _selectedSurveyNumber.asStateFlow()
 
     val surveyList: StateFlow<List<Survey>>
         get() = _surveyList.asStateFlow()
@@ -50,6 +55,10 @@ class HomeViewModel @Inject constructor(
 
     val userAvatar: StateFlow<String?>
         get() = _userAvatar.asStateFlow()
+
+    fun setSelectedSurveyNumber(surveyNumber: Int) {
+        _selectedSurveyNumber.value = surveyNumber
+    }
 
     private fun getUserDetail() {
         viewModelScope.launch(ioDispatcher) {
@@ -81,6 +90,7 @@ class HomeViewModel @Inject constructor(
             homeRepo.clearSurveyList()
             _currentPageNumber.value = DEFAULT_CURRENT_PAGE
             totalNumberOfPage = DEFAULT_NUMBER_OF_PAGE
+            _selectedSurveyNumber.value = START_SURVEY_NUMBER
             getSurveyListFromDb()
             getSurveyList()
         }


### PR DESCRIPTION
Closes #78 

## What happened 👀

When back from survey detail screen, selected survey index in home screen returns to default(ie. 0)

## Insight 📝

- Store selected survey page number in view model to avoid being reset to default value when the screen is resume
- Use the stored page number in Home Screen

## Proof Of Work 📹


https://user-images.githubusercontent.com/32578035/187837816-11e42ae8-4a74-4ccd-8b52-200c15ec2ece.mp4


