### PR TITLE
[#22] Integrate survey question screen

### DIFF
--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/AndroidTestConstants.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/AndroidTestConstants.kt
@@ -10,35 +10,22 @@ val surveys = listOf(
     Survey(id = "2", coverImagePlaceholderUrl = "", title = "title2", description = "description2")
 )
 
-val surveyQuestions = listOf(
-    SurveyQuestion(
-        id = "0",
-        title = "title question",
-        displayOrder = 0,
-        shortText = "",
-        pick = "none",
-        questionDisplayType = QuestionDisplayType.NONE,
-        answers = listOf(
-            SurveyAnswer(
-                id = "0",
-                text = "text",
-                displayOrder = 0
-            )
-        )
-    ),
-    SurveyQuestion(
-        id = "1",
-        title = "title",
-        displayOrder = 0,
-        shortText = "",
-        pick = "none",
-        questionDisplayType = QuestionDisplayType.NONE,
-        answers = listOf(
-            SurveyAnswer(
-                id = "0",
-                text = "text",
-                displayOrder = 0
-            )
+val surveyQuestion = SurveyQuestion(
+    id = "0",
+    title = "title question",
+    displayOrder = 0,
+    shortText = "",
+    pick = "none",
+    questionDisplayType = QuestionDisplayType.NONE,
+    answers = listOf(
+        SurveyAnswer(
+            id = "0",
+            text = "text",
+            displayOrder = 0
         )
     )
+)
+val surveyQuestions = listOf(
+    surveyQuestion,
+    surveyQuestion.copy(id = "1", title = "title")
 )

--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/AndroidTestConstants.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/AndroidTestConstants.kt
@@ -1,8 +1,44 @@
 package com.kks.nimblesurveyjetpackcompose
 
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
 import com.kks.nimblesurveyjetpackcompose.model.Survey
+import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
+import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
 
 val surveys = listOf(
     Survey(id = "1", coverImagePlaceholderUrl = "", title = "title1", description = "description1"),
     Survey(id = "2", coverImagePlaceholderUrl = "", title = "title2", description = "description2")
+)
+
+val surveyQuestions = listOf(
+    SurveyQuestion(
+        id = "0",
+        title = "title question",
+        displayOrder = 0,
+        shortText = "",
+        pick = "none",
+        questionDisplayType = QuestionDisplayType.NONE,
+        answers = listOf(
+            SurveyAnswer(
+                id = "0",
+                text = "text",
+                displayOrder = 0
+            )
+        )
+    ),
+    SurveyQuestion(
+        id = "1",
+        title = "title",
+        displayOrder = 0,
+        shortText = "",
+        pick = "none",
+        questionDisplayType = QuestionDisplayType.NONE,
+        answers = listOf(
+            SurveyAnswer(
+                id = "0",
+                text = "text",
+                displayOrder = 0
+            )
+        )
+    )
 )

--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/di/FakeRepoModule.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/di/FakeRepoModule.kt
@@ -2,6 +2,7 @@ package com.kks.nimblesurveyjetpackcompose.di
 
 import com.kks.nimblesurveyjetpackcompose.repo.home.HomeRepo
 import com.kks.nimblesurveyjetpackcompose.repo.login.LoginRepo
+import com.kks.nimblesurveyjetpackcompose.repo.survey.SurveyRepo
 import com.kks.nimblesurveyjetpackcompose.ui.presentation.splash.FakeLoginRepo
 import dagger.Module
 import dagger.Provides
@@ -23,4 +24,8 @@ class FakeRepoModule {
     @Singleton
     @Provides
     fun provideFakeHomeRepo(): HomeRepo =  mockk()
+
+    @Singleton
+    @Provides
+    fun provideFakeSurveyRepo(): SurveyRepo = mockk()
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
@@ -1,0 +1,7 @@
+package com.kks.nimblesurveyjetpackcompose.model
+
+data class SurveyAnswer(
+    val id: String,
+    val text: String,
+    val displayOrder: Int
+)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -11,12 +11,12 @@ data class SurveyQuestion(
 )
 
 enum class QuestionDisplayType(val typeValue: String) {
-    NONE("none"), INTRO("intro"), DROP_DROWN("dropdown")
+    NONE("none"), INTRO("intro"), DROPDOWN("dropdown")
 }
 
 fun String.getQuestionDisplayType() =
     when (this) {
         QuestionDisplayType.INTRO.typeValue -> QuestionDisplayType.INTRO
-        QuestionDisplayType.DROP_DROWN.typeValue -> QuestionDisplayType.DROP_DROWN
+        QuestionDisplayType.DROPDOWN.typeValue -> QuestionDisplayType.DROPDOWN
         else -> QuestionDisplayType.NONE
     }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -1,5 +1,22 @@
 package com.kks.nimblesurveyjetpackcompose.model
 
 data class SurveyQuestion(
-    val title: String
+    val id: String,
+    val title: String,
+    val displayOrder: Int,
+    val shortText: String,
+    val pick: String,
+    val questionDisplayType: QuestionDisplayType,
+    var answers: List<SurveyAnswer>
 )
+
+enum class QuestionDisplayType(val typeValue: String) {
+    NONE("none"), INTRO("intro"), DROP_DROWN("dropdown")
+}
+
+fun String.getQuestionDisplayType() =
+    when (this) {
+        QuestionDisplayType.INTRO.typeValue -> QuestionDisplayType.INTRO
+        QuestionDisplayType.DROP_DROWN.typeValue -> QuestionDisplayType.DROP_DROWN
+        else -> QuestionDisplayType.NONE
+    }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/IncludedResponse.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/IncludedResponse.kt
@@ -1,5 +1,8 @@
 package com.kks.nimblesurveyjetpackcompose.model.response
 
+import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
+import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
+import com.kks.nimblesurveyjetpackcompose.model.getQuestionDisplayType
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
@@ -39,6 +42,17 @@ data class IncludedQuestionResponse(
     )
 }
 
+fun IncludedQuestionResponse.toSurveyQuestion() =
+    SurveyQuestion(
+        id = id.orEmpty(),
+        title = attributes?.text.orEmpty().trim(),
+        displayOrder = attributes?.displayOrder ?: 0,
+        shortText = attributes?.shortText.orEmpty(),
+        pick = attributes?.pick.orEmpty(),
+        questionDisplayType = attributes?.displayType.orEmpty().getQuestionDisplayType(),
+        answers = emptyList()
+    )
+
 @JsonClass(generateAdapter = true)
 data class IncludedAnswerResponse(
     @Json(name = "id") val id: String? = null,
@@ -68,3 +82,10 @@ data class IncludedAnswerResponse(
         @Json(name = "alerts") var alerts: List<String> = emptyList()
     )
 }
+
+fun IncludedAnswerResponse.toSurveyAnswer() =
+    SurveyAnswer(
+        id = id.orEmpty(),
+        text = attributes?.text.orEmpty().trim(),
+        displayOrder = attributes?.displayOrder ?: 0
+    )

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepo.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepo.kt
@@ -1,9 +1,9 @@
 package com.kks.nimblesurveyjetpackcompose.repo.survey
 
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
-import com.kks.nimblesurveyjetpackcompose.model.response.IncludedResponse
+import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
 import kotlinx.coroutines.flow.Flow
 
 interface SurveyRepo {
-    fun getSurveyDetails(surveyId: String): Flow<ResourceState<List<IncludedResponse>>>
+    fun getSurveyDetails(surveyId: String): Flow<ResourceState<List<SurveyQuestion>>>
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
@@ -2,7 +2,12 @@ package com.kks.nimblesurveyjetpackcompose.repo.survey
 
 import com.kks.nimblesurveyjetpackcompose.di.ServiceQualifier
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
-import com.kks.nimblesurveyjetpackcompose.model.response.IncludedResponse
+import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
+import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
+import com.kks.nimblesurveyjetpackcompose.model.response.IncludedAnswerResponse
+import com.kks.nimblesurveyjetpackcompose.model.response.IncludedQuestionResponse
+import com.kks.nimblesurveyjetpackcompose.model.response.toSurveyAnswer
+import com.kks.nimblesurveyjetpackcompose.model.response.toSurveyQuestion
 import com.kks.nimblesurveyjetpackcompose.network.Api
 import com.kks.nimblesurveyjetpackcompose.util.extensions.safeApiCall
 import kotlinx.coroutines.Dispatchers
@@ -12,12 +17,31 @@ import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class SurveyRepoImpl @Inject constructor(@ServiceQualifier private val api: Api) : SurveyRepo {
-    override fun getSurveyDetails(surveyId: String): Flow<ResourceState<List<IncludedResponse>>> =
+    override fun getSurveyDetails(surveyId: String): Flow<ResourceState<List<SurveyQuestion>>> =
         flow {
             emit(ResourceState.Loading)
             val apiResult = safeApiCall(Dispatchers.IO) { api.getSurveyDetail(surveyId = surveyId) }
             when (apiResult) {
-                is ResourceState.Success -> emit(ResourceState.Success(apiResult.data.included.orEmpty()))
+                is ResourceState.Success -> {
+                    apiResult.data.included?.let { includedList ->
+                        val answers = includedList.filterIsInstance<IncludedAnswerResponse>()
+                            .map { it.toSurveyAnswer() }
+                            .groupBy { it.id }
+                        val questions = includedList.filterIsInstance<IncludedQuestionResponse>()
+                            .map { questionResponse ->
+                                questionResponse.toSurveyQuestion().also { surveyQuestion ->
+                                    val tempAnsList = arrayListOf<SurveyAnswer>()
+                                    questionResponse.relationships?.answers?.data?.forEach { surveyDataResponse ->
+                                        answers[surveyDataResponse.id]?.first { surveyAnswer ->
+                                            tempAnsList.add(surveyAnswer)
+                                        }
+                                    }
+                                    surveyQuestion.answers = tempAnsList
+                                }
+                            }
+                        emit(ResourceState.Success(questions))
+                    }
+                }
                 is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))
                 else -> emit(ResourceState.NetworkError)
             }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
@@ -2,7 +2,6 @@ package com.kks.nimblesurveyjetpackcompose.repo.survey
 
 import com.kks.nimblesurveyjetpackcompose.di.ServiceQualifier
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
-import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
 import com.kks.nimblesurveyjetpackcompose.model.response.IncludedAnswerResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.IncludedQuestionResponse
@@ -30,13 +29,12 @@ class SurveyRepoImpl @Inject constructor(@ServiceQualifier private val api: Api)
                         val questions = includedList.filterIsInstance<IncludedQuestionResponse>()
                             .map { questionResponse ->
                                 questionResponse.toSurveyQuestion().also { surveyQuestion ->
-                                    val tempAnsList = arrayListOf<SurveyAnswer>()
-                                    questionResponse.relationships?.answers?.data?.forEach { surveyDataResponse ->
-                                        answers[surveyDataResponse.id]?.first { surveyAnswer ->
-                                            tempAnsList.add(surveyAnswer)
-                                        }
-                                    }
-                                    surveyQuestion.answers = tempAnsList
+                                    val answerList = questionResponse.relationships
+                                        ?.answers
+                                        ?.data
+                                        ?.mapNotNull { answers[it.id]?.firstOrNull() }
+                                        .orEmpty()
+                                    surveyQuestion.answers = answerList
                                 }
                             }
                         emit(ResourceState.Success(questions))

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -71,7 +71,7 @@ fun SurveyDetailScreen(
     viewModel: SurveyDetailViewModel = hiltViewModel()
 ) {
     val currentPage by viewModel.currentPage.collectAsState()
-    val surveyQuestions by viewModel.surveyQuestionList.collectAsState()
+    val surveyQuestions by viewModel.surveyQuestions.collectAsState()
     val shouldShowLoading by viewModel.shouldShowLoading.collectAsState()
     val error by viewModel.error.collectAsState()
     var showConfirmDialog by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -50,6 +50,7 @@ import com.google.accompanist.pager.rememberPagerState
 import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.model.Survey
 import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.ConfirmAlertDialog
+import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.ErrorAlertDialog
 import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.Loading
 import com.kks.nimblesurveyjetpackcompose.ui.theme.BlackRussian
 import com.kks.nimblesurveyjetpackcompose.ui.theme.NeuzeitFamily
@@ -72,6 +73,7 @@ fun SurveyDetailScreen(
     val currentPage by viewModel.currentPage.collectAsState()
     val surveyQuestions by viewModel.surveyQuestionList.collectAsState()
     val shouldShowLoading by viewModel.shouldShowLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
     var showConfirmDialog by remember { mutableStateOf(false) }
     val startSurveyDescription = stringResource(id = R.string.survey_detail_start_survey)
     val placeholderPainter = rememberAsyncImagePainter(model = survey.coverImagePlaceholderUrl)
@@ -169,6 +171,14 @@ fun SurveyDetailScreen(
             )
         }
         if (shouldShowLoading) Loading()
+        error?.let { error ->
+            ErrorAlertDialog(
+                errorModel = error,
+                title = stringResource(id = R.string.oops),
+                buttonText = stringResource(id = android.R.string.ok),
+                onClickButton = { viewModel.resetError() }
+            )
+        }
     }
 }
 
@@ -210,6 +220,7 @@ fun NextQuestionButton(
     onNextSlide: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val nextQuestionDescription = stringResource(id = R.string.survey_question_next_question)
     Crossfade(
         targetState = showButton,
         animationSpec = tween(TWEEN_ANIM_TIME),
@@ -220,12 +231,13 @@ fun NextQuestionButton(
                 onClick = { onNextSlide() },
                 modifier = Modifier
                     .clip(CircleShape)
-                    .size(56.dp),
+                    .size(56.dp)
+                    .semantics { contentDescription = nextQuestionDescription },
                 colors = ButtonDefaults.buttonColors(backgroundColor = Color.White)
             ) {
                 Image(
                     painter = painterResource(id = R.drawable.ic_baseline_arrow_forward_ios_24),
-                    contentDescription = stringResource(id = R.string.home_survey_detail_button)
+                    contentDescription = null
                 )
             }
         }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kks.nimblesurveyjetpackcompose.R
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White50
 
@@ -34,5 +35,17 @@ fun SurveyQuestionScreen(surveyQuestion: SurveyQuestion, pageNumber: Int, totalN
 @Preview
 @Composable
 fun SurveyQuestionScreenPreview() {
-    SurveyQuestionScreen(surveyQuestion = SurveyQuestion(title = "Title"), pageNumber = 1, totalNumberOfPage = 5)
+    SurveyQuestionScreen(
+        surveyQuestion = SurveyQuestion(
+            id = "",
+            title = "",
+            displayOrder = 0,
+            shortText = "",
+            pick = "",
+            questionDisplayType = QuestionDisplayType.NONE,
+            answers = emptyList()
+        ),
+        pageNumber = 1,
+        totalNumberOfPage = 5
+    )
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
@@ -3,9 +3,7 @@ package com.kks.nimblesurveyjetpackcompose.viewmodel.survey
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kks.nimblesurveyjetpackcompose.di.IoDispatcher
-import com.kks.nimblesurveyjetpackcompose.model.ErrorModel
-import com.kks.nimblesurveyjetpackcompose.model.ResourceState
-import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
+import com.kks.nimblesurveyjetpackcompose.model.*
 import com.kks.nimblesurveyjetpackcompose.repo.survey.SurveyRepo
 import com.kks.nimblesurveyjetpackcompose.util.extensions.mapError
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
@@ -53,7 +53,7 @@ class SurveyDetailViewModel @Inject constructor(
                     }
                     is ResourceState.Success -> {
                         _shouldShowLoading.value = false
-                        _surveyQuestionList.value = it.data
+                        _surveyQuestions.value = it.data
                         resetError()
                     }
                     else -> {


### PR DESCRIPTION
Closes #22 

## What happened 👀

When a user starts taking a survey, he/she will go through a set of questions of the selected survey. The mobile app should show how many questions there are for the survey so that the user can expect how long it is going to take and he/she can always stop at any point by dismissing the screen.

- Use the survey's cover image url as the background image
- Show the actual current question number and the number of questions on the Question Number label
- {{current-question-number}}/{{number-of-questions}}
- By default, the starting number is 1.
- Show the current question's text on the Question label
- Tapping the Next button and swiping should change the current question number.
- The Question and Question Number labels should be updated in that respect

## Insight 📝

- Add ui models
- Integrate with api calls
- Refactor ui test which has been ignored since there is no ViewModel for `SurveyDetailScreen` in UI ticket

## Proof Of Work 📹


https://user-images.githubusercontent.com/32578035/188308061-454acb83-1ea5-4fd3-989b-1f9452ae168f.mp4


