### PR TITLE
[#26] Backend implementation to submit survey

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
@@ -1,7 +1,12 @@
 package com.kks.nimblesurveyjetpackcompose.model
 
+import com.kks.nimblesurveyjetpackcompose.model.request.SurveyAnswerRequest
+
 data class SurveyAnswer(
     val id: String,
-    val text: String,
-    val displayOrder: Int
+    var text: String,
+    val displayOrder: Int,
+    var selected: Boolean = false
 )
+
+fun SurveyAnswer.toSurveyAnswerRequest(): SurveyAnswerRequest = SurveyAnswerRequest(id = id, answer = text)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -1,5 +1,7 @@
 package com.kks.nimblesurveyjetpackcompose.model
 
+import com.kks.nimblesurveyjetpackcompose.model.request.SurveyQuestionRequest
+
 data class SurveyQuestion(
     val id: String,
     val title: String,
@@ -13,6 +15,9 @@ data class SurveyQuestion(
 enum class QuestionDisplayType(val typeValue: String) {
     NONE("none"), INTRO("intro"), DROPDOWN("dropdown")
 }
+
+fun SurveyQuestion.toSurveyQuestionRequest(): SurveyQuestionRequest =
+    SurveyQuestionRequest(id = id, answers = answers.filter { it.selected }.map { it.toSurveyAnswerRequest() })
 
 fun String.getQuestionDisplayType() =
     when (this) {

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/request/SubmitSurveyRequest.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/request/SubmitSurveyRequest.kt
@@ -1,0 +1,12 @@
+package com.kks.nimblesurveyjetpackcompose.model.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SubmitSurveyRequest(
+    @Json(name = "survey_id")
+    val surveyId: String,
+    @Json(name = "questions")
+    val questions: List<SurveyQuestionRequest>
+)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/request/SurveyAnswerRequest.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/request/SurveyAnswerRequest.kt
@@ -1,0 +1,12 @@
+package com.kks.nimblesurveyjetpackcompose.model.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+open class SurveyAnswerRequest(
+    @Json(name = "id")
+    val id: String,
+    @Json(name = "answer")
+    val answer: String? = null
+)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/request/SurveyQuestionRequest.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/request/SurveyQuestionRequest.kt
@@ -1,0 +1,12 @@
+package com.kks.nimblesurveyjetpackcompose.model.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SurveyQuestionRequest(
+    @Json(name = "id")
+    val id: String,
+    @Json(name = "answers")
+    val answers: List<SurveyAnswerRequest>
+)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/network/Api.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/network/Api.kt
@@ -29,5 +29,5 @@ interface Api {
     suspend fun getSurveyDetail(@Path("surveyId") surveyId: String): BaseResponse<SurveyResponse>
 
     @POST("api/v1/responses")
-    suspend fun submitSurvey(@Body submitSurveyRequest: SubmitSurveyRequest): BaseResponse<SubmitSurveyRequest>
+    suspend fun submitSurvey(@Body submitSurveyRequest: SubmitSurveyRequest): BaseResponse<Any>
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/network/Api.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/network/Api.kt
@@ -1,6 +1,7 @@
 package com.kks.nimblesurveyjetpackcompose.network
 
 import com.kks.nimblesurveyjetpackcompose.model.request.LoginRequest
+import com.kks.nimblesurveyjetpackcompose.model.request.SubmitSurveyRequest
 import com.kks.nimblesurveyjetpackcompose.model.response.BaseResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.LoginResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.SurveyResponse
@@ -26,4 +27,7 @@ interface Api {
 
     @GET("api/v1/surveys/{surveyId}")
     suspend fun getSurveyDetail(@Path("surveyId") surveyId: String): BaseResponse<SurveyResponse>
+
+    @POST("api/v1/responses")
+    suspend fun submitSurvey(@Body submitSurveyRequest: SubmitSurveyRequest): BaseResponse<SubmitSurveyRequest>
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepo.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepo.kt
@@ -6,4 +6,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface SurveyRepo {
     fun getSurveyDetails(surveyId: String): Flow<ResourceState<List<SurveyQuestion>>>
+    fun submitSurvey(surveyId: String, surveyQuestions: List<SurveyQuestion>): Flow<ResourceState<Unit>>
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
@@ -3,10 +3,12 @@ package com.kks.nimblesurveyjetpackcompose.repo.survey
 import com.kks.nimblesurveyjetpackcompose.di.ServiceQualifier
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
+import com.kks.nimblesurveyjetpackcompose.model.request.SubmitSurveyRequest
 import com.kks.nimblesurveyjetpackcompose.model.response.IncludedAnswerResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.IncludedQuestionResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.toSurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.response.toSurveyQuestion
+import com.kks.nimblesurveyjetpackcompose.model.toSurveyQuestionRequest
 import com.kks.nimblesurveyjetpackcompose.network.Api
 import com.kks.nimblesurveyjetpackcompose.util.extensions.safeApiCall
 import kotlinx.coroutines.Dispatchers
@@ -46,4 +48,24 @@ class SurveyRepoImpl @Inject constructor(@ServiceQualifier private val api: Api)
         }.catch { error ->
             emit(ResourceState.Error(error.message.orEmpty()))
         }
+
+    override fun submitSurvey(surveyId: String, surveyQuestions: List<SurveyQuestion>): Flow<ResourceState<Unit>> =
+        flow {
+            emit(ResourceState.Loading)
+            val apiResult = safeApiCall(Dispatchers.IO) {
+                api.submitSurvey(
+                    submitSurveyRequest = surveyQuestions.toSubmitSurveyRequest(surveyId)
+                )
+            }
+            when (apiResult) {
+                is ResourceState.Success -> emit(ResourceState.Success(Unit))
+                is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))
+                else -> emit(ResourceState.NetworkError)
+            }
+        }.catch { error ->
+            emit(ResourceState.Error(error.message.orEmpty()))
+        }
 }
+
+private fun List<SurveyQuestion>.toSubmitSurveyRequest(surveyId: String): SubmitSurveyRequest =
+    SubmitSurveyRequest(surveyId = surveyId, questions = this.map { it.toSurveyQuestionRequest() })


### PR DESCRIPTION
Closes #26 

## What happened 👀

At the final step, users must be able to submit their responses. The mobile app must show the Submit button instead of the Next button to inform users that the app will submit their response on the next action.

## Insight 📝

- Add `POST /api/v1/responses` endpoint
- Add request object
- Add repository implementation

## Proof Of Work 📹
![Screenshot_20220905_183010](https://user-images.githubusercontent.com/32578035/188439979-96ed8ddf-1cc3-4028-bbe3-30e0b906a1bf.png)

![Screenshot_20220905_183024](https://user-images.githubusercontent.com/32578035/188439950-25899559-a49a-431b-8a05-7659f4494ec3.png)

