### PR TITLE
[#25] Integrate submit survey screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -194,6 +194,9 @@ dependencies {
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
 
+    // Lottie
+    implementation "com.airbnb.android:lottie-compose:$lottie_version"
+
     // Mockk
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "io.mockk:mockk-agent-jvm:$mockk_version"

--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/splash/SplashScreenTest.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/splash/SplashScreenTest.kt
@@ -132,7 +132,7 @@ class SplashScreenTest : BaseAndroidComposeTest() {
                 .performTextInput(VALID_PASSWORD)
             onNodeWithContentDescription(getString(R.string.login_log_in_button))
                 .performClick()
-            waitForIdle()
+            waitUntil { splashViewModel.isLoginSuccess.value }
             assertTrue(splashViewModel.isLoginSuccess.value)
         }
     }
@@ -147,6 +147,7 @@ class SplashScreenTest : BaseAndroidComposeTest() {
                 .performTextInput(INVALID_PASSWORD)
             onNodeWithContentDescription(getString(R.string.login_log_in_button))
                 .performClick()
+            waitForIdle()
             onNodeWithText(ERROR_MESSAGE).assertIsDisplayed()
         }
     }

--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyHomeDetailScreenKtTest.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyHomeDetailScreenKtTest.kt
@@ -76,6 +76,17 @@ class SurveyHomeDetailScreenKtTest : BaseAndroidComposeTest() {
         }
     }
 
+    @Test
+    fun when_click_on_next_question_button_and_reach_the_end_of_survey_list_show_submit_button() {
+        with(composeTestRule) {
+            onNodeWithContentDescription(getString(R.string.survey_detail_start_survey)).performClick()
+            waitForIdle()
+            onNodeWithContentDescription(getString(R.string.survey_question_next_question)).performClick()
+            waitForIdle()
+            onNodeWithText(getString(R.string.survey_question_submit_survey)).assertIsDisplayed()
+        }
+    }
+
     private fun setupSurveyHomeDetailScreen(survey: Survey) {
         composeTestRule.activity.setContent {
             NimbleSurveyJetpackComposeTheme {

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -37,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
@@ -44,6 +46,11 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.animateLottieCompositionAsState
+import com.airbnb.lottie.compose.rememberLottieComposition
+import com.airbnb.lottie.compose.rememberLottieRetrySignal
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.rememberPagerState
@@ -62,6 +69,10 @@ import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
 import kotlinx.coroutines.launch
 
+private const val SUBMIT_SUCCESS_LOTTIE_URL = "https://assets2.lottiefiles.com/packages/lf20_pmYw5P.json"
+private const val LOTTIE_ENDS = 1.0f
+private const val LOTTIE_FAIL_COUNT = 3
+
 @OptIn(ExperimentalPagerApi::class)
 @Destination
 @Composable
@@ -73,6 +84,7 @@ fun SurveyDetailScreen(
     val currentPage by viewModel.currentPage.collectAsState()
     val surveyQuestions by viewModel.surveyQuestions.collectAsState()
     val shouldShowLoading by viewModel.shouldShowLoading.collectAsState()
+    val isSurveySubmitSuccess by viewModel.shouldShowLottie.collectAsState()
     val error by viewModel.error.collectAsState()
     var showConfirmDialog by remember { mutableStateOf(false) }
     val startSurveyDescription = stringResource(id = R.string.survey_detail_start_survey)
@@ -87,7 +99,7 @@ fun SurveyDetailScreen(
         else navigator.popBackStack()
     }
 
-    LaunchedEffect(key1 = pagerState) {
+    LaunchedEffect(key1 = pagerState, key2 = isSurveySubmitSuccess) {
         snapshotFlow { pagerState.currentPage }.collect { page ->
             viewModel.setCurrentPage(page)
         }
@@ -145,7 +157,7 @@ fun SurveyDetailScreen(
                         pagerState.animateScrollToPage(currentPage + 1)
                     }
                 } else {
-                    // TODO: Implement submit survey action
+                    viewModel.submitSurvey(surveyId = survey.id)
                 }
             },
             modifier = Modifier
@@ -153,6 +165,7 @@ fun SurveyDetailScreen(
                 .padding(bottom = 54.dp, end = 20.dp)
                 .semantics { contentDescription = startSurveyDescription }
         )
+        if (isSurveySubmitSuccess) LottieView(navigator = navigator)
         NextQuestionButton(
             showButton = !isStartPage && !isLastPage,
             onNextSlide = {
@@ -186,6 +199,39 @@ fun SurveyDetailScreen(
                 onClickButton = { viewModel.resetError() }
             )
         }
+    }
+}
+
+@Composable
+fun LottieView(navigator: DestinationsNavigator) {
+    val retrySignal = rememberLottieRetrySignal()
+    val composition by rememberLottieComposition(
+        LottieCompositionSpec.Url(SUBMIT_SUCCESS_LOTTIE_URL),
+        onRetry = { failCount, _ ->
+            retrySignal.awaitRetry()
+            failCount < LOTTIE_FAIL_COUNT
+        }
+    )
+    val progress by animateLottieCompositionAsState(composition)
+
+    if (progress == LOTTIE_ENDS) navigator.popBackStack()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Color.Black),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        LottieAnimation(composition)
+        Text(
+            text = stringResource(id = R.string.survey_question_thanks),
+            fontFamily = NeuzeitFamily,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+            fontSize = 28.sp,
+            textAlign = TextAlign.Center
+        )
     }
 }
 

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -84,7 +84,7 @@ fun SurveyDetailScreen(
     val currentPage by viewModel.currentPage.collectAsState()
     val surveyQuestions by viewModel.surveyQuestions.collectAsState()
     val shouldShowLoading by viewModel.shouldShowLoading.collectAsState()
-    val shouldShowLottie by viewModel.shouldShowLottie.collectAsState()
+    val shouldShowThanks by viewModel.shouldShowLottie.collectAsState()
     val error by viewModel.error.collectAsState()
     var showConfirmDialog by remember { mutableStateOf(false) }
     val startSurveyDescription = stringResource(id = R.string.survey_detail_start_survey)
@@ -165,7 +165,7 @@ fun SurveyDetailScreen(
                 .padding(bottom = 54.dp, end = 20.dp)
                 .semantics { contentDescription = startSurveyDescription }
         )
-        if (shouldShowLottie) LottieView(navigator = navigator)
+        if (shouldShowThanks) LottieView(navigator = navigator)
         NextQuestionButton(
             showButton = !isStartPage && !isLastPage,
             onNextSlide = {

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -84,7 +84,7 @@ fun SurveyDetailScreen(
     val currentPage by viewModel.currentPage.collectAsState()
     val surveyQuestions by viewModel.surveyQuestions.collectAsState()
     val shouldShowLoading by viewModel.shouldShowLoading.collectAsState()
-    val shouldShowThanks by viewModel.shouldShowLottie.collectAsState()
+    val shouldShowThanks by viewModel.shouldShowThanks.collectAsState()
     val error by viewModel.error.collectAsState()
     var showConfirmDialog by remember { mutableStateOf(false) }
     val startSurveyDescription = stringResource(id = R.string.survey_detail_start_survey)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -156,7 +156,7 @@ fun SurveyDetailScreen(
                     scope.launch {
                         pagerState.animateScrollToPage(currentPage + 1)
                     }
-                } else {
+                } else if (isLastPage) {
                     viewModel.submitSurvey(surveyId = survey.id)
                 }
             },

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -84,7 +84,7 @@ fun SurveyDetailScreen(
     val currentPage by viewModel.currentPage.collectAsState()
     val surveyQuestions by viewModel.surveyQuestions.collectAsState()
     val shouldShowLoading by viewModel.shouldShowLoading.collectAsState()
-    val isSurveySubmitSuccess by viewModel.shouldShowLottie.collectAsState()
+    val shouldShowLottie by viewModel.shouldShowLottie.collectAsState()
     val error by viewModel.error.collectAsState()
     var showConfirmDialog by remember { mutableStateOf(false) }
     val startSurveyDescription = stringResource(id = R.string.survey_detail_start_survey)
@@ -99,7 +99,7 @@ fun SurveyDetailScreen(
         else navigator.popBackStack()
     }
 
-    LaunchedEffect(key1 = pagerState, key2 = isSurveySubmitSuccess) {
+    LaunchedEffect(key1 = pagerState) {
         snapshotFlow { pagerState.currentPage }.collect { page ->
             viewModel.setCurrentPage(page)
         }
@@ -165,7 +165,7 @@ fun SurveyDetailScreen(
                 .padding(bottom = 54.dp, end = 20.dp)
                 .semantics { contentDescription = startSurveyDescription }
         )
-        if (isSurveySubmitSuccess) LottieView(navigator = navigator)
+        if (shouldShowLottie) LottieView(navigator = navigator)
         NextQuestionButton(
             showButton = !isStartPage && !isLastPage,
             onNextSlide = {

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
@@ -70,22 +70,24 @@ class SurveyDetailViewModel @Inject constructor(
     }
 
     fun submitSurvey(surveyId: String) {
-        viewModelScope.launch(ioDispatcher) {
-            surveyRepo.submitSurvey(surveyId = surveyId, surveyQuestions = _surveyQuestionList.value).collect {
-                when (it) {
-                    is ResourceState.Loading -> {
-                        _shouldShowLoading.value = true
-                        resetError()
-                    }
-                    is ResourceState.Success -> {
-                        _shouldShowLoading.value = false
-                        _shouldShowLottie.value = true
-                        resetError()
-                    }
-                    else -> {
-                        _shouldShowLoading.value = false
-                        it.mapError()?.let { errorModel ->
-                            _error.value = errorModel
+        if (_currentPage.value == _surveyQuestionList.value.size) {
+            viewModelScope.launch(ioDispatcher) {
+                surveyRepo.submitSurvey(surveyId = surveyId, surveyQuestions = _surveyQuestionList.value).collect {
+                    when (it) {
+                        is ResourceState.Loading -> {
+                            _shouldShowLoading.value = true
+                            resetError()
+                        }
+                        is ResourceState.Success -> {
+                            _shouldShowLoading.value = false
+                            _shouldShowLottie.value = true
+                            resetError()
+                        }
+                        else -> {
+                            _shouldShowLoading.value = false
+                            it.mapError()?.let { errorModel ->
+                                _error.value = errorModel
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
@@ -70,24 +70,22 @@ class SurveyDetailViewModel @Inject constructor(
     }
 
     fun submitSurvey(surveyId: String) {
-        if (_currentPage.value == _surveyQuestions.value.size) {
-            viewModelScope.launch(ioDispatcher) {
-                surveyRepo.submitSurvey(surveyId = surveyId, surveyQuestions = _surveyQuestions.value).collect {
-                    when (it) {
-                        is ResourceState.Loading -> {
-                            _shouldShowLoading.value = true
-                            resetError()
-                        }
-                        is ResourceState.Success -> {
-                            _shouldShowLoading.value = false
-                            _shouldShowThanks.value = true
-                            resetError()
-                        }
-                        else -> {
-                            _shouldShowLoading.value = false
-                            it.mapError()?.let { errorModel ->
-                                _error.value = errorModel
-                            }
+        viewModelScope.launch(ioDispatcher) {
+            surveyRepo.submitSurvey(surveyId = surveyId, surveyQuestions = _surveyQuestions.value).collect {
+                when (it) {
+                    is ResourceState.Loading -> {
+                        _shouldShowLoading.value = true
+                        resetError()
+                    }
+                    is ResourceState.Success -> {
+                        _shouldShowLoading.value = false
+                        _shouldShowThanks.value = true
+                        resetError()
+                    }
+                    else -> {
+                        _shouldShowLoading.value = false
+                        it.mapError()?.let { errorModel ->
+                            _error.value = errorModel
                         }
                     }
                 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
@@ -24,7 +24,7 @@ class SurveyDetailViewModel @Inject constructor(
     private val _surveyQuestions = MutableStateFlow(emptyList<SurveyQuestion>())
     private val _shouldShowLoading = MutableStateFlow(false)
     private val _error = MutableStateFlow<ErrorModel?>(null)
-    private val _shouldShowLottie = MutableStateFlow(false)
+    private val _shouldShowThanks = MutableStateFlow(false)
 
     val error: StateFlow<ErrorModel?>
         get() = _error.asStateFlow()
@@ -42,8 +42,8 @@ class SurveyDetailViewModel @Inject constructor(
         _currentPage.value = pageNumber
     }
 
-    val shouldShowLottie: StateFlow<Boolean>
-        get() = _shouldShowLottie.asStateFlow()
+    val shouldShowThanks: StateFlow<Boolean>
+        get() = _shouldShowThanks.asStateFlow()
 
     fun getSurveyQuestions(surveyId: String) {
         viewModelScope.launch(ioDispatcher) {
@@ -80,7 +80,7 @@ class SurveyDetailViewModel @Inject constructor(
                         }
                         is ResourceState.Success -> {
                             _shouldShowLoading.value = false
-                            _shouldShowLottie.value = true
+                            _shouldShowThanks.value = true
                             resetError()
                         }
                         else -> {

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
@@ -70,9 +70,9 @@ class SurveyDetailViewModel @Inject constructor(
     }
 
     fun submitSurvey(surveyId: String) {
-        if (_currentPage.value == _surveyQuestionList.value.size) {
+        if (_currentPage.value == _surveyQuestions.value.size) {
             viewModelScope.launch(ioDispatcher) {
-                surveyRepo.submitSurvey(surveyId = surveyId, surveyQuestions = _surveyQuestionList.value).collect {
+                surveyRepo.submitSurvey(surveyId = surveyId, surveyQuestions = _surveyQuestions.value).collect {
                     when (it) {
                         is ResourceState.Loading -> {
                             _shouldShowLoading.value = true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="survey_detail_close_icon">Survey detail close icon</string>
     <string name="survey_detail_background_image">Survey detail background image</string>
     <string name="survey_detail_start_survey">Start Survey</string>
+    <string name="survey_detail_next_question_btn">Next question button</string>
 
     <!--SurveyQuestion-->
     <string name="survey_question_number">%d/%d</string>
@@ -42,4 +43,5 @@
     <string name="survey_question_warning_dialog_cancel">Cancel</string>
     <string name="survey_question_next_question">Survey next question</string>
     <string name="survey_question_submit_survey">Submit</string>
+    <string name="survey_question_thanks">Thanks for taking\nthe survey.</string>
 </resources>

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/UnitTestConstants.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/UnitTestConstants.kt
@@ -4,35 +4,22 @@ import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
 
-val surveyQuestions = listOf(
-    SurveyQuestion(
-        id = "0",
-        title = "title question",
-        displayOrder = 0,
-        shortText = "",
-        pick = "none",
-        questionDisplayType = QuestionDisplayType.NONE,
-        answers = listOf(
-            SurveyAnswer(
-                id = "0",
-                text = "text",
-                displayOrder = 0
-            )
-        )
-    ),
-    SurveyQuestion(
-        id = "1",
-        title = "title",
-        displayOrder = 0,
-        shortText = "",
-        pick = "none",
-        questionDisplayType = QuestionDisplayType.NONE,
-        answers = listOf(
-            SurveyAnswer(
-                id = "0",
-                text = "text",
-                displayOrder = 0
-            )
+val surveyQuestion = SurveyQuestion(
+    id = "0",
+    title = "title question",
+    displayOrder = 0,
+    shortText = "",
+    pick = "none",
+    questionDisplayType = QuestionDisplayType.NONE,
+    answers = listOf(
+        SurveyAnswer(
+            id = "0",
+            text = "text",
+            displayOrder = 0
         )
     )
+)
+val surveyQuestions = listOf(
+    surveyQuestion,
+    surveyQuestion.copy(id = "1", title = "title")
 )

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/UnitTestConstants.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/UnitTestConstants.kt
@@ -1,0 +1,38 @@
+package com.kks.nimblesurveyjetpackcompose
+
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
+import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
+import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
+
+val surveyQuestions = listOf(
+    SurveyQuestion(
+        id = "0",
+        title = "title question",
+        displayOrder = 0,
+        shortText = "",
+        pick = "none",
+        questionDisplayType = QuestionDisplayType.NONE,
+        answers = listOf(
+            SurveyAnswer(
+                id = "0",
+                text = "text",
+                displayOrder = 0
+            )
+        )
+    ),
+    SurveyQuestion(
+        id = "1",
+        title = "title",
+        displayOrder = 0,
+        shortText = "",
+        pick = "none",
+        questionDisplayType = QuestionDisplayType.NONE,
+        answers = listOf(
+            SurveyAnswer(
+                id = "0",
+                text = "text",
+                displayOrder = 0
+            )
+        )
+    )
+)

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
@@ -25,7 +25,7 @@ class SurveyDetailViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `When get survey questions and return error, show error`()= runTest {
+    fun `When get survey questions and return error, show error`() = runTest {
         val errorMessage = "error"
         val errorState: ResourceState<List<SurveyQuestion>> = ResourceState.Error(errorMessage)
         coEvery { surveyRepo.getSurveyDetails(any()) } returns flowOf(errorState)
@@ -37,7 +37,7 @@ class SurveyDetailViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `When get survey questions and return success, show survey list`()= runTest {
+    fun `When get survey questions and return success, show survey list`() = runTest {
         val successState: ResourceState<List<SurveyQuestion>> = ResourceState.Success(surveyQuestions)
         coEvery { surveyRepo.getSurveyDetails(any()) } returns flowOf(successState)
 
@@ -48,7 +48,7 @@ class SurveyDetailViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `When submit survey and return error, show error`()= runTest {
+    fun `When submit survey and return error, show error`() = runTest {
         val errorMessage = "error"
         val errorState: ResourceState<Unit> = ResourceState.Error(errorMessage)
         coEvery { surveyRepo.submitSurvey(any(), any()) } returns flowOf(errorState)
@@ -60,7 +60,7 @@ class SurveyDetailViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `When submit survey and return success, show lottie`()= runTest {
+    fun `When submit survey and return success, show lottie`() = runTest {
         val successState: ResourceState<Unit> = ResourceState.Success(Unit)
         coEvery { surveyRepo.submitSurvey(any(), any()) } returns flowOf(successState)
 

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
@@ -60,7 +60,7 @@ class SurveyDetailViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `When submit survey and return success, show lottie`() = runTest {
+    fun `When submit survey and return success, show thanks`() = runTest {
         val successState: ResourceState<Unit> = ResourceState.Success(Unit)
         coEvery { surveyRepo.submitSurvey(any(), any()) } returns flowOf(successState)
 

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
@@ -44,7 +44,7 @@ class SurveyDetailViewModelTest : BaseViewModelTest() {
         viewModel.getSurveyQuestions(surveyId = "1")
         advanceUntilIdle()
 
-        assertEquals(surveyQuestions, viewModel.surveyQuestionList.value)
+        assertEquals(surveyQuestions, viewModel.surveyQuestions.value)
     }
 
     @Test

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
@@ -1,0 +1,72 @@
+package com.kks.nimblesurveyjetpackcompose.viewmodel.survey
+
+import com.kks.nimblesurveyjetpackcompose.base.BaseViewModelTest
+import com.kks.nimblesurveyjetpackcompose.model.ResourceState
+import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
+import com.kks.nimblesurveyjetpackcompose.repo.survey.SurveyRepo
+import com.kks.nimblesurveyjetpackcompose.surveyQuestions
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SurveyDetailViewModelTest : BaseViewModelTest() {
+    private lateinit var viewModel: SurveyDetailViewModel
+    private val surveyRepo: SurveyRepo = mockk()
+
+    override fun setup() {
+        super.setup()
+        viewModel = SurveyDetailViewModel(surveyRepo = surveyRepo, ioDispatcher = testDispatcher)
+    }
+
+    @Test
+    fun `When get survey questions and return error, show error`()= runTest {
+        val errorMessage = "error"
+        val errorState: ResourceState<List<SurveyQuestion>> = ResourceState.Error(errorMessage)
+        coEvery { surveyRepo.getSurveyDetails(any()) } returns flowOf(errorState)
+
+        viewModel.getSurveyQuestions(surveyId = "1")
+        advanceUntilIdle()
+
+        assertEquals(errorMessage, viewModel.error.value?.errorMessage)
+    }
+
+    @Test
+    fun `When get survey questions and return success, show survey list`()= runTest {
+        val successState: ResourceState<List<SurveyQuestion>> = ResourceState.Success(surveyQuestions)
+        coEvery { surveyRepo.getSurveyDetails(any()) } returns flowOf(successState)
+
+        viewModel.getSurveyQuestions(surveyId = "1")
+        advanceUntilIdle()
+
+        assertEquals(surveyQuestions, viewModel.surveyQuestionList.value)
+    }
+
+    @Test
+    fun `When submit survey and return error, show error`()= runTest {
+        val errorMessage = "error"
+        val errorState: ResourceState<Unit> = ResourceState.Error(errorMessage)
+        coEvery { surveyRepo.submitSurvey(any(), any()) } returns flowOf(errorState)
+
+        viewModel.submitSurvey(surveyId = "1")
+        advanceUntilIdle()
+
+        assertEquals(errorMessage, viewModel.error.value?.errorMessage)
+    }
+
+    @Test
+    fun `When submit survey and return success, show lottie`()= runTest {
+        val successState: ResourceState<Unit> = ResourceState.Success(Unit)
+        coEvery { surveyRepo.submitSurvey(any(), any()) } returns flowOf(successState)
+
+        viewModel.submitSurvey(surveyId = "1")
+        advanceUntilIdle()
+
+        assertEquals(true, viewModel.shouldShowLottie.value)
+    }
+}

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
@@ -67,6 +67,6 @@ class SurveyDetailViewModelTest : BaseViewModelTest() {
         viewModel.submitSurvey(surveyId = "1")
         advanceUntilIdle()
 
-        assertEquals(true, viewModel.shouldShowLottie.value)
+        assertEquals(true, viewModel.shouldShowThanks.value)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
         hilt_compose_version = "1.0.0"
         lifecycle_runtime_version = '2.3.1'
         kover_version = '0.5.1'
+        lottie_version = '5.2.0'
         mockk_version = '1.12.5'
         moshiVersion = "1.13.0"
         okhttp_version = "4.9.3"

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ pluginManagement {
         google()
         mavenCentral()
         maven { url 'https://plugins.gradle.org/m2/' }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 dependencyResolutionManagement {


### PR DESCRIPTION
Closes #25 

## What happened 👀

At the final step, users must be able to submit their responses. The mobile app must show the Submit button instead of the Next button to inform users that the app will submit their response on the next action.

Upon tapping the Submit button, perform the Submit Survey Response request with the survey id and the user's answers.
- If the request is successful,
  - Show a Lottie-based animation (or alternative) on completing the survey and navigate the user back to Home
- Otherwise, display the error message on a modal alert dialog with an OK button
  - Selecting the OK button does nothing. DO NOT dismiss the screen so that the user can retry the submission.

## Insight 📝

- Integrate submit survey with UI
- Implement Lottie view

## Proof Of Work 📹

[Show us the implementation: screenshots, gif, etc.
](https://user-images.githubusercontent.com/32578035/188624550-e5d2db42-920a-4969-9786-3c054bc2ea93.mp4)