### PR TITLE
[#28] Integrate dropdown question

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
@@ -6,7 +6,9 @@ data class SurveyAnswer(
     val id: String,
     var text: String,
     val displayOrder: Int,
-    var selected: Boolean = false
+    var selected: Boolean = false,
+    var isIdOnlyAnswer: Boolean = false
 )
 
-fun SurveyAnswer.toSurveyAnswerRequest(): SurveyAnswerRequest = SurveyAnswerRequest(id = id, answer = text)
+fun SurveyAnswer.toSurveyAnswerRequest(): SurveyAnswerRequest =
+    if (isIdOnlyAnswer) SurveyAnswerRequest(id = id) else SurveyAnswerRequest(id = id, answer = text)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/request/SurveyAnswerRequest.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/request/SurveyAnswerRequest.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-open class SurveyAnswerRequest(
+data class SurveyAnswerRequest(
     @Json(name = "id")
     val id: String,
     @Json(name = "answer")

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
@@ -323,7 +324,8 @@ fun SurveyBoldText(
     fontSize: TextUnit,
     modifier: Modifier = Modifier,
     color: Color = Color.White,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip
 ) {
     Text(
         text = text,
@@ -332,7 +334,8 @@ fun SurveyBoldText(
         color = color,
         fontSize = fontSize,
         maxLines = maxLines,
-        modifier = modifier.fillMaxWidth()
+        modifier = modifier.fillMaxWidth(),
+        overflow = overflow
     )
 }
 

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -135,7 +135,9 @@ fun SurveyDetailScreen(
                     surveyQuestion = surveyQuestions[page - 1],
                     pageNumber = page,
                     totalNumberOfPage = surveyQuestions.size
-                )
+                ) { questionId, surveyAnswers ->
+                    viewModel.setAnswers(questionId = questionId, answers = surveyAnswers)
+                }
             }
         }
         SurveyToolbar(

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -40,6 +41,13 @@ fun SurveyDropDownQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers
     var expanded by remember { mutableStateOf(false) }
     var selectedIndex by remember { mutableStateOf(if (answerIndex == INVALID_INDEX) 0 else answerIndex) }
     var rowSize by remember { mutableStateOf(Size.Zero) }
+    LaunchedEffect(key1 = selectedIndex) {
+        onChooseAnswer(
+            answers.mapIndexed { index, surveyAnswer ->
+                surveyAnswer.copy(selected = index == selectedIndex)
+            }
+        )
+    }
     Box {
         Row(
             modifier = Modifier
@@ -49,13 +57,11 @@ fun SurveyDropDownQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers
                 .onGloballyPositioned { rowSize = it.size.toSize() },
             verticalAlignment = Alignment.CenterVertically
         ) {
-            onChooseAnswer(
-                answers.toMutableList().also { it[selectedIndex] = answers[selectedIndex].copy(selected = true) }
-            )
             SurveyBoldText(
                 text = answers[selectedIndex].text,
                 fontSize = 20.sp,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
@@ -32,10 +32,13 @@ import androidx.compose.ui.unit.toSize
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.ui.theme.Black60
 
+private const val INVALID_INDEX = -1
+
 @Composable
-fun SurveyDropdownQuestion(answers: List<SurveyAnswer>) {
+fun SurveyDropDownQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit) {
+    val answerIndex = answers.indexOfFirst { it.selected }
     var expanded by remember { mutableStateOf(false) }
-    var selectedIndex by remember { mutableStateOf(0) }
+    var selectedIndex by remember { mutableStateOf(if (answerIndex == INVALID_INDEX) 0 else answerIndex) }
     var rowSize by remember { mutableStateOf(Size.Zero) }
     Box {
         Row(
@@ -46,6 +49,9 @@ fun SurveyDropdownQuestion(answers: List<SurveyAnswer>) {
                 .onGloballyPositioned { rowSize = it.size.toSize() },
             verticalAlignment = Alignment.CenterVertically
         ) {
+            onChooseAnswer(
+                answers.toMutableList().also { it[selectedIndex] = answers[selectedIndex].copy(selected = true) }
+            )
             SurveyBoldText(
                 text = answers[selectedIndex].text,
                 fontSize = 20.sp,
@@ -68,7 +74,7 @@ fun SurveyDropdownQuestion(answers: List<SurveyAnswer>) {
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            modifier = Modifier.width(with(LocalDensity.current) { rowSize.width.toDp() }),
+            modifier = Modifier.size(width = with(LocalDensity.current) { rowSize.width.toDp() }, height = 150.dp),
         ) {
             answers.forEachIndexed { index, surveyAnswer ->
                 DropdownMenuItem(
@@ -86,6 +92,8 @@ fun SurveyDropdownQuestion(answers: List<SurveyAnswer>) {
 
 @Preview(showBackground = true)
 @Composable
-fun SurveyDropdownQuestionPreview() {
-    SurveyDropdownQuestion(listOf())
+fun SurveyDropDownQuestionPreview() {
+    SurveyDropDownQuestion(listOf()) {
+        // Do nothing
+    }
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
@@ -44,7 +44,7 @@ fun SurveyDropDownQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers
     LaunchedEffect(key1 = selectedIndex) {
         onChooseAnswer(
             answers.mapIndexed { index, surveyAnswer ->
-                surveyAnswer.copy(selected = index == selectedIndex)
+                surveyAnswer.copy(selected = index == selectedIndex, isIdOnlyAnswer = true)
             }
         )
     }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -14,11 +14,17 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
+import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White50
 
 @Composable
-fun SurveyQuestionScreen(surveyQuestion: SurveyQuestion, pageNumber: Int, totalNumberOfPage: Int) {
+fun SurveyQuestionScreen(
+    surveyQuestion: SurveyQuestion,
+    pageNumber: Int,
+    totalNumberOfPage: Int,
+    onChooseAnswer: (questionId: String, surveyAnswers: List<SurveyAnswer>) -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -36,7 +42,9 @@ fun SurveyQuestionScreen(surveyQuestion: SurveyQuestion, pageNumber: Int, totalN
         SurveyBoldText(text = surveyQuestion.title, fontSize = 34.sp)
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             if (surveyQuestion.questionDisplayType == QuestionDisplayType.DROPDOWN) {
-                SurveyDropdownQuestion(answers = surveyQuestion.answers)
+                SurveyDropDownQuestion(answers = surveyQuestion.answers) {
+                    onChooseAnswer(surveyQuestion.id, it)
+                }
             }
         }
     }
@@ -57,5 +65,7 @@ fun SurveyQuestionScreenPreview() {
         ),
         pageNumber = 1,
         totalNumberOfPage = 5
-    )
+    ) { _, _ ->
+        // Do nothing
+    }
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModel.kt
@@ -45,6 +45,11 @@ class SurveyDetailViewModel @Inject constructor(
     val shouldShowThanks: StateFlow<Boolean>
         get() = _shouldShowThanks.asStateFlow()
 
+    fun setAnswers(questionId: String, answers: List<SurveyAnswer>) {
+        val indexOfQuestion = _surveyQuestions.value.indexOfFirst { it.id == questionId }
+        _surveyQuestions.value[indexOfQuestion].answers = answers
+    }
+
     fun getSurveyQuestions(surveyId: String) {
         viewModelScope.launch(ioDispatcher) {
             surveyRepo.getSurveyDetails(surveyId).collect {

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/survey/SurveyDetailViewModelTest.kt
@@ -69,4 +69,18 @@ class SurveyDetailViewModelTest : BaseViewModelTest() {
 
         assertEquals(true, viewModel.shouldShowThanks.value)
     }
+
+    @Test
+    fun `When setAnswers from dropdown, survey list should have one item with selected true`() = runTest {
+        val successState: ResourceState<List<SurveyQuestion>> = ResourceState.Success(surveyQuestions)
+        coEvery { surveyRepo.getSurveyDetails(any()) } returns flowOf(successState)
+        viewModel.getSurveyQuestions(surveyId = "1")
+
+        advanceUntilIdle()
+
+        val question = surveyQuestions.first()
+        val answers = question.answers.toMutableList().apply { this.first().selected = true }
+        viewModel.setAnswers(questionId = question.id, answers = answers)
+        assertEquals(viewModel.surveyQuestions.value.first().answers, answers)
+    }
 }


### PR DESCRIPTION
Closes #28 

## What happened 👀

Dropdown questions are one of the most common question types to allow users to select one answer. The dropdown options could be anything, such as, a set of cities, locations, or even yes/no, since they are text-based options.
Even though this is called a dropdown, to provide the mobile experience, we will use a native picker wheel for this type of question.

When a Question model has display_type as dropdown,
- Display a dropdown menu in the Answer section
- Apply the answers as picker items
- Use the answer's text to show as the picker item's title
- By default, the first answer is initially selected

## Insight 📝

- Integrate answers data to the picker menu
- Set the first item as selected by default

**KNOW ISSUE: `DropdownMenu` uses `Column` to show `DropdownMenuItem` instead of `LazyColumn`. Large list of dropdown menus affects the application's responsiveness.**

## Proof Of Work 📹



https://user-images.githubusercontent.com/32578035/190360344-5ca83251-c1ef-43ba-bbe7-ff242d34e53f.mp4



