### PR TITLE
[#30] [#31] Integrate smiley rating question

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
@@ -6,9 +6,8 @@ data class SurveyAnswer(
     val id: String,
     var text: String,
     val displayOrder: Int,
-    var selected: Boolean = false,
-    var isIdOnlyAnswer: Boolean = false
+    var selected: Boolean = false
 )
 
-fun SurveyAnswer.toSurveyAnswerRequest(): SurveyAnswerRequest =
+fun SurveyAnswer.toSurveyAnswerRequest(isIdOnlyAnswer: Boolean): SurveyAnswerRequest =
     if (isIdOnlyAnswer) SurveyAnswerRequest(id = id) else SurveyAnswerRequest(id = id, answer = text)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -12,19 +12,27 @@ data class SurveyQuestion(
     var answers: List<SurveyAnswer>
 )
 
-enum class QuestionDisplayType(val typeValue: String) {
-    NONE("none"),
-    INTRO("intro"),
-    DROPDOWN("dropdown"),
-    SMILEY("smiley")
+enum class QuestionDisplayType(val typeValue: String, val isIdOnlyAnswer: Boolean) {
+    NONE("none", false),
+    INTRO("intro", false),
+    DROPDOWN("dropdown", true),
+    SMILEY("smiley", true)
 }
 
+fun List<SurveyAnswer>.sortedByDisplayOrder(): List<SurveyAnswer> = this.sortedBy { it.displayOrder }
+
 fun SurveyQuestion.toSurveyQuestionRequest(): SurveyQuestionRequest =
-    SurveyQuestionRequest(id = id, answers = answers.filter { it.selected }.map { it.toSurveyAnswerRequest() })
+    SurveyQuestionRequest(
+        id = id,
+        answers = answers.filter { it.selected }.map {
+            it.toSurveyAnswerRequest(isIdOnlyAnswer = questionDisplayType.isIdOnlyAnswer)
+        }
+    )
 
 fun String.getQuestionDisplayType() =
     when (this) {
         QuestionDisplayType.INTRO.typeValue -> QuestionDisplayType.INTRO
         QuestionDisplayType.DROPDOWN.typeValue -> QuestionDisplayType.DROPDOWN
+        QuestionDisplayType.SMILEY.typeValue -> QuestionDisplayType.SMILEY
         else -> QuestionDisplayType.NONE
     }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
@@ -58,9 +58,6 @@ fun SurveyDropDownQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers
                 .onGloballyPositioned { rowSize = it.size.toSize() },
             verticalAlignment = Alignment.CenterVertically
         ) {
-            onChooseAnswer(
-                answers.toMutableList().also { it[selectedIndex] = answers[selectedIndex].copy(selected = true) }
-            )
             SurveyBoldText(
                 text = answers[selectedIndex].text,
                 fontSize = 20.sp,

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
@@ -45,7 +45,7 @@ fun SurveyDropDownQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers
     LaunchedEffect(key1 = selectedIndex) {
         onChooseAnswer(
             answers.mapIndexed { index, surveyAnswer ->
-                surveyAnswer.copy(selected = index == selectedIndex, isIdOnlyAnswer = true)
+                surveyAnswer.copy(selected = index == selectedIndex)
             }
         )
     }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestion.kt
@@ -58,6 +58,9 @@ fun SurveyDropDownQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers
                 .onGloballyPositioned { rowSize = it.size.toSize() },
             verticalAlignment = Alignment.CenterVertically
         ) {
+            onChooseAnswer(
+                answers.toMutableList().also { it[selectedIndex] = answers[selectedIndex].copy(selected = true) }
+            )
             SurveyBoldText(
                 text = answers[selectedIndex].text,
                 fontSize = 20.sp,

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -19,6 +19,8 @@ import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
 import com.kks.nimblesurveyjetpackcompose.model.sortedByDisplayOrder
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White50
 
+private const val NUMBER_OF_SMILEY_ANSWERS = 5
+
 @Composable
 fun SurveyQuestionScreen(
     surveyQuestion: SurveyQuestion,
@@ -47,7 +49,7 @@ fun SurveyQuestionScreen(
                     SurveyDropDownQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
                         onChooseAnswer(surveyQuestion.id, it)
                     }
-                SMILEY -> if (surveyQuestion.answers.size >= 5) {
+                SMILEY -> if (surveyQuestion.answers.size >= NUMBER_OF_SMILEY_ANSWERS) {
                     SurveySmileyQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
                         onChooseAnswer(surveyQuestion.id, it)
                     }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -13,7 +13,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kks.nimblesurveyjetpackcompose.R
-import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.*
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.DROPDOWN
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.NONE
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.SMILEY
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
 import com.kks.nimblesurveyjetpackcompose.model.sortedByDisplayOrder
@@ -45,10 +47,9 @@ fun SurveyQuestionScreen(
         SurveyBoldText(text = surveyQuestion.title, fontSize = 34.sp)
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             when (surveyQuestion.questionDisplayType) {
-                DROPDOWN ->
-                    SurveyDropDownQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
-                        onChooseAnswer(surveyQuestion.id, it)
-                    }
+                DROPDOWN -> SurveyDropDownQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
+                    onChooseAnswer(surveyQuestion.id, it)
+                }
                 SMILEY -> if (surveyQuestion.answers.size >= NUMBER_OF_SMILEY_ANSWERS) {
                     SurveySmileyQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
                         onChooseAnswer(surveyQuestion.id, it)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -16,6 +16,7 @@ import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.*
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
+import com.kks.nimblesurveyjetpackcompose.model.sortedByDisplayOrder
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White50
 
 @Composable
@@ -42,10 +43,15 @@ fun SurveyQuestionScreen(
         SurveyBoldText(text = surveyQuestion.title, fontSize = 34.sp)
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             when (surveyQuestion.questionDisplayType) {
-                DROPDOWN -> SurveyDropDownQuestion(answers = surveyQuestion.answers) {
-                    onChooseAnswer(surveyQuestion.id, it)
+                DROPDOWN ->
+                    SurveyDropDownQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
+                        onChooseAnswer(surveyQuestion.id, it)
+                    }
+                SMILEY -> if (surveyQuestion.answers.size >= 5) {
+                    SurveySmileyQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
+                        onChooseAnswer(surveyQuestion.id, it)
+                    }
                 }
-                SMILEY -> SurveySmileyQuestion()
                 else -> {
                     // Do nothing
                 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveySmileyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveySmileyQuestion.kt
@@ -16,16 +16,24 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
+import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.ui.theme.Black50
 
 private val SMILEY_EMOJIS = listOf("😡", "😕", "😐", "🙂", "😄")
 
 @Composable
-fun SurveySmileyQuestion() {
+fun SurveySmileyQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit) {
     var selectedIndex by remember { mutableStateOf(-1) }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
         SMILEY_EMOJIS.forEachIndexed { index, text ->
-            TextButton(onClick = { selectedIndex = index }) {
+            TextButton(onClick = {
+                selectedIndex = index
+                onChooseAnswer(
+                    answers.mapIndexed { index, surveyAnswer ->
+                        surveyAnswer.copy(selected = index == selectedIndex)
+                    }
+                )
+            }) {
                 Text(
                     text = text,
                     color = if (selectedIndex == index) Color.Unspecified else Black50,
@@ -39,5 +47,7 @@ fun SurveySmileyQuestion() {
 @Preview(showBackground = true)
 @Composable
 fun PreviewSurveySmileyQuestion() {
-    SurveySmileyQuestion()
+    SurveySmileyQuestion(listOf()) {
+        // Do nothing
+    }
 }


### PR DESCRIPTION
Closes #30 #31 

## What happened 👀

For Smiley Rating questions, users can rate their satisfaction by tapping on the smiley face. This works like a normal rating from 1-5 stars question, but we will use smiley emojis instead of stars
A valid Smiley question must have 5 answers in the response. If the number of answers is fewer than 5, it is invalid. If it is more than 5, we will only use the first five answers as this case is not supposed to happen.

## Insight 📝

When a Question model has display_type as smiley,
- Display a Smiley Rating question
- Use the answers as the rating options in an orderly manner
- A valid Smiley question must have 5 answers. If the number of answers is fewer than 5, treat it as an invalid question
- If the number of answers is more than five, use only the first five answers
- By default, none are initially selected

## Proof Of Work 📹

https://user-images.githubusercontent.com/32578035/190385777-a7a41d49-0755-49a2-8d39-c3ccd6a3453c.mp4


