### PR TITLE
[#94] Fix IncludedResponse declared alerts as wrong type

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/IncludedResponse.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/IncludedResponse.kt
@@ -83,11 +83,11 @@ data class IncludedAnswerResponse(
     ) {
         @JsonClass(generateAdapter = true)
         data class AlertResponse(
-            @Json(name = "id") var id: String? = null,
-            @Json(name = "alert_type") var alertType: String? = null,
-            @Json(name = "recipient") var recipient: String? = null,
-            @Json(name = "is_only_business_hours") var isOnlyBusinessHours: Boolean? = null,
-            @Json(name = "answer_id") var answerId: String? = null
+            @Json(name = "id") val id: String? = null,
+            @Json(name = "alert_type") val alertType: String? = null,
+            @Json(name = "recipient") val recipient: String? = null,
+            @Json(name = "is_only_business_hours") val isOnlyBusinessHours: Boolean? = null,
+            @Json(name = "answer_id") val answerId: String? = null
         )
     }
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/IncludedResponse.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/IncludedResponse.kt
@@ -79,8 +79,17 @@ data class IncludedAnswerResponse(
         @Json(name = "response_class") var responseClass: String? = null,
         @Json(name = "reference_identifier") var referenceIdentifier: String? = null,
         @Json(name = "score") var score: Int? = null,
-        @Json(name = "alerts") var alerts: List<String> = emptyList()
-    )
+        @Json(name = "alerts") var alerts: List<AlertResponse> = emptyList()
+    ) {
+        @JsonClass(generateAdapter = true)
+        data class AlertResponse(
+            @Json(name = "id") var id: String? = null,
+            @Json(name = "alert_type") var alertType: String? = null,
+            @Json(name = "recipient") var recipient: String? = null,
+            @Json(name = "is_only_business_hours") var isOnlyBusinessHours: Boolean? = null,
+            @Json(name = "answer_id") var answerId: String? = null
+        )
+    }
 }
 
 fun IncludedAnswerResponse.toSurveyAnswer() =


### PR DESCRIPTION
closes #94 

## What happened 👀

`alerts` in `IncludedResponse` is declared with wrong type and having deserializing error when `alerts` is not null.

## Insight 📝

Refactor `alerts` from `List<String>` type to `List<AlertResponse>` type with the following response:
```
 "alerts": [
                    {
                        "id": "683bf1be2bd1703c7915",
                        "alert_type": "email",
                        "recipient": "chsuphawadee@tops.co.th",
                        "is_only_business_hours": true,
                        "answer_id": "d781429576834e54a3ce"
                    },
                    {
                        "id": "c043d0a9070952bf0c32",
                        "alert_type": "email",
                        "recipient": "Chwilaiwan@tops.co.th",
                        "is_only_business_hours": true,
                        "answer_id": "d781429576834e54a3ce"
                    },
                    {
                        "id": "3933b5cfc146c7981dd0",
                        "alert_type": "email",
                        "recipient": "cusserv@tops.co.th",
                        "is_only_business_hours": true,
                        "answer_id": "d781429576834e54a3ce"
                    }
                ]
```

## Proof Of Work 📹

https://user-images.githubusercontent.com/32578035/190597475-32a9e5ba-ac98-48dd-b207-188ca1bfd7a1.mp4

