### PR TITLE
[#32] Implement Thumbs Emoji screen

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -16,7 +16,8 @@ enum class QuestionDisplayType(val typeValue: String, val isIdOnlyAnswer: Boolea
     NONE("none", false),
     INTRO("intro", false),
     DROPDOWN("dropdown", true),
-    SMILEY("smiley", true)
+    SMILEY("smiley", true),
+    THUMBS("thumbs", true)
 }
 
 fun List<SurveyAnswer>.sortedByDisplayOrder(): List<SurveyAnswer> = this.sortedBy { it.displayOrder }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestion.kt
@@ -1,31 +1,42 @@
 package com.kks.nimblesurveyjetpackcompose.ui.presentation.survey
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.runtime.*
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.ui.theme.Black50
 
 private val SMILEY_EMOJIS = listOf("😡", "😕", "😐", "🙂", "😄")
+private val THUMBS_EMOJIS = listOf("\uD83D\uDC4D", "\uD83D\uDC4D", "\uD83D\uDC4D", "\uD83D\uDC4D", "\uD83D\uDC4D")
 
 @Composable
-fun SurveySmileyQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit) {
-    var selectedIndex by remember { mutableStateOf(-1) }
+fun SurveyEmojiQuestion(
+    answers: List<SurveyAnswer>,
+    questionDisplayType: QuestionDisplayType,
+    onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit
+) {
+    var selectedIndex by remember { mutableStateOf(answers.indexOfFirst { it.selected }) }
+    val isShowAllLeftEmoji = questionDisplayType != QuestionDisplayType.SMILEY
+
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-        SMILEY_EMOJIS.forEachIndexed { index, text ->
+
+        when (questionDisplayType) {
+            QuestionDisplayType.SMILEY -> SMILEY_EMOJIS
+            QuestionDisplayType.THUMBS -> THUMBS_EMOJIS
+            else -> listOf()
+        }.forEachIndexed { index, text ->
             TextButton(onClick = {
                 selectedIndex = index
                 onChooseAnswer(
@@ -36,7 +47,11 @@ fun SurveySmileyQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers: 
             }) {
                 Text(
                     text = text,
-                    color = if (selectedIndex == index) Color.Unspecified else Black50,
+                    color = if (selectedIndex == index || (isShowAllLeftEmoji && index <= selectedIndex)) {
+                        Color.Unspecified
+                    } else {
+                        Black50
+                    },
                     fontSize = 28.sp
                 )
             }
@@ -47,7 +62,8 @@ fun SurveySmileyQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers: 
 @Preview(showBackground = true)
 @Composable
 fun PreviewSurveySmileyQuestion() {
-    SurveySmileyQuestion(listOf()) {
+    SurveyEmojiQuestion(answers = listOf(), questionDisplayType = QuestionDisplayType.SMILEY) {
         // Do nothing
     }
 }
+

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestion.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.SMILEY
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.THUMBS
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.ui.theme.Black50
 
@@ -28,12 +30,12 @@ fun SurveyEmojiQuestion(
     onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit
 ) {
     var selectedIndex by remember { mutableStateOf(answers.indexOfFirst { it.selected }) }
-    val shouldHighlightAllLeftEmojis = questionDisplayType != QuestionDisplayType.SMILEY
+    val shouldHighlightAllLeftEmojis = questionDisplayType != SMILEY
 
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
         when (questionDisplayType) {
-            QuestionDisplayType.SMILEY -> SMILEY_EMOJIS
-            QuestionDisplayType.THUMBS -> THUMBS_EMOJIS
+            SMILEY -> SMILEY_EMOJIS
+            THUMBS -> THUMBS_EMOJIS
             else -> emptyList()
         }.forEachIndexed { index, text ->
             TextButton(onClick = {
@@ -61,7 +63,7 @@ fun SurveyEmojiQuestion(
 @Preview(showBackground = true)
 @Composable
 fun PreviewSurveySmileyQuestion() {
-    SurveyEmojiQuestion(answers = emptyList(), questionDisplayType = QuestionDisplayType.SMILEY) {
+    SurveyEmojiQuestion(answers = emptyList(), questionDisplayType = SMILEY) {
         // Do nothing
     }
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestion.kt
@@ -28,14 +28,13 @@ fun SurveyEmojiQuestion(
     onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit
 ) {
     var selectedIndex by remember { mutableStateOf(answers.indexOfFirst { it.selected }) }
-    val isShowAllLeftEmoji = questionDisplayType != QuestionDisplayType.SMILEY
+    val shouldHighlightAllLeftEmojis = questionDisplayType != QuestionDisplayType.SMILEY
 
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-
         when (questionDisplayType) {
             QuestionDisplayType.SMILEY -> SMILEY_EMOJIS
             QuestionDisplayType.THUMBS -> THUMBS_EMOJIS
-            else -> listOf()
+            else -> emptyList()
         }.forEachIndexed { index, text ->
             TextButton(onClick = {
                 selectedIndex = index
@@ -47,7 +46,7 @@ fun SurveyEmojiQuestion(
             }) {
                 Text(
                     text = text,
-                    color = if (selectedIndex == index || (isShowAllLeftEmoji && index <= selectedIndex)) {
+                    color = if (selectedIndex == index || (shouldHighlightAllLeftEmojis && index <= selectedIndex)) {
                         Color.Unspecified
                     } else {
                         Black50
@@ -62,7 +61,7 @@ fun SurveyEmojiQuestion(
 @Preview(showBackground = true)
 @Composable
 fun PreviewSurveySmileyQuestion() {
-    SurveyEmojiQuestion(answers = listOf(), questionDisplayType = QuestionDisplayType.SMILEY) {
+    SurveyEmojiQuestion(answers = emptyList(), questionDisplayType = QuestionDisplayType.SMILEY) {
         // Do nothing
     }
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -51,7 +51,8 @@ fun SurveyQuestionScreen(
                 DROPDOWN -> SurveyDropDownQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
                     onChooseAnswer(surveyQuestion.id, it)
                 }
-                SMILEY, THUMBS -> if (surveyQuestion.answers.size >= NUMBER_OF_EMOJI_ANSWERS) {
+                SMILEY,
+                THUMBS -> if (surveyQuestion.answers.size >= NUMBER_OF_EMOJI_ANSWERS) {
                     SurveyEmojiQuestion(
                         answers = surveyQuestion.answers.sortedByDisplayOrder(),
                         questionDisplayType = surveyQuestion.questionDisplayType

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -16,12 +16,13 @@ import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.DROPDOWN
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.NONE
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.SMILEY
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.THUMBS
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
 import com.kks.nimblesurveyjetpackcompose.model.sortedByDisplayOrder
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White50
 
-private const val NUMBER_OF_SMILEY_ANSWERS = 5
+private const val NUMBER_OF_EMOJI_ANSWERS = 5
 
 @Composable
 fun SurveyQuestionScreen(
@@ -50,8 +51,11 @@ fun SurveyQuestionScreen(
                 DROPDOWN -> SurveyDropDownQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
                     onChooseAnswer(surveyQuestion.id, it)
                 }
-                SMILEY -> if (surveyQuestion.answers.size >= NUMBER_OF_SMILEY_ANSWERS) {
-                    SurveySmileyQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
+                SMILEY, THUMBS -> if (surveyQuestion.answers.size >= NUMBER_OF_EMOJI_ANSWERS) {
+                    SurveyEmojiQuestion(
+                        answers = surveyQuestion.answers.sortedByDisplayOrder(),
+                        questionDisplayType = surveyQuestion.questionDisplayType
+                    ) {
                         onChooseAnswer(surveyQuestion.id, it)
                     }
                 }
@@ -82,3 +86,4 @@ fun SurveyQuestionScreenPreview() {
         // Do nothing
     }
 }
+


### PR DESCRIPTION
Closes #32 

## What happened 👀

For Emoji Rating questions, users can rate their satisfaction by tapping on the emoji. This works like a normal rating from 1-5 stars question, but we will use emojis instead of stars
It is worth to mention that there are two Rating Question UI types.

**Smiley Rating**
- Use different emojis on each rating level
- It highlights only the selected one.

**Emoji Rating**
- Use repeated emojis for all rating level
- It highlights the selected one and all emojis on the left-hand side of the selected one.

## Insight 📝

For Emoji Rating questions,
- Display emojis as the options
  - By default, use 👍🏻 emoji.
  - Please note that it could be other emojis as well depending on the question type.
- Select any option should highlight every other emoji on its left
  - For instance, if a user selects the third emoji, the first, second, and third emoji should be highlighted.
- Reduce the opacity of the non-selected range emojis

## Proof Of Work 📹



https://user-images.githubusercontent.com/32578035/191024341-1056ecaa-e075-43f4-8a6e-ce4b9ba4d978.mp4