### PR TITLE
[#33] [#34] Integrate Thumbs Emoji screen and add tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -209,6 +209,9 @@ dependencies {
     // Turbine
     testImplementation("app.cash.turbine:turbine:${Versions.TURBINE}")
 
+    // Google Truth
+    testImplementation("com.google.truth:truth:${Versions.TRUTH}")
+
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:${Versions.COMPOSE}")

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyAnswer.kt
@@ -11,3 +11,5 @@ data class SurveyAnswer(
 
 fun SurveyAnswer.toSurveyAnswerRequest(isIdOnlyAnswer: Boolean): SurveyAnswerRequest =
     if (isIdOnlyAnswer) SurveyAnswerRequest(id = id) else SurveyAnswerRequest(id = id, answer = text)
+
+fun List<SurveyAnswer>.sortedByDisplayOrder(): List<SurveyAnswer> = this.sortedBy { it.displayOrder }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -20,7 +20,7 @@ enum class QuestionDisplayType(val typeValue: String, val isIdOnlyAnswer: Boolea
     THUMBS("thumbs", true)
 }
 
-fun List<SurveyAnswer>.sortedByDisplayOrder(): List<SurveyAnswer> = this.sortedBy { it.displayOrder }
+fun List<SurveyQuestion>.sortedByDisplayOrder(): List<SurveyQuestion> = this.sortedBy { it.displayOrder }
 
 fun SurveyQuestion.toSurveyQuestionRequest(): SurveyQuestionRequest =
     SurveyQuestionRequest(

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
@@ -8,6 +8,7 @@ import com.kks.nimblesurveyjetpackcompose.model.response.IncludedAnswerResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.IncludedQuestionResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.toSurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.response.toSurveyQuestion
+import com.kks.nimblesurveyjetpackcompose.model.sortedByDisplayOrder
 import com.kks.nimblesurveyjetpackcompose.model.toSurveyQuestionRequest
 import com.kks.nimblesurveyjetpackcompose.network.Api
 import com.kks.nimblesurveyjetpackcompose.util.extensions.safeApiCall
@@ -35,11 +36,12 @@ class SurveyRepoImpl @Inject constructor(@ServiceQualifier private val api: Api)
                                         ?.answers
                                         ?.data
                                         ?.mapNotNull { answers[it.id]?.firstOrNull() }
+                                        ?.sortedByDisplayOrder()
                                         .orEmpty()
                                     surveyQuestion.answers = answerList
                                 }
                             }
-                        emit(ResourceState.Success(questions))
+                        emit(ResourceState.Success(questions.sortedByDisplayOrder()))
                     }
                 }
                 is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -19,7 +19,6 @@ import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.SMILEY
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.THUMBS
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
-import com.kks.nimblesurveyjetpackcompose.model.sortedByDisplayOrder
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White50
 
 private const val NUMBER_OF_EMOJI_ANSWERS = 5
@@ -48,12 +47,12 @@ fun SurveyQuestionScreen(
         SurveyBoldText(text = surveyQuestion.title, fontSize = 34.sp)
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             when (surveyQuestion.questionDisplayType) {
-                DROPDOWN -> SurveyDropDownQuestion(answers = surveyQuestion.answers.sortedByDisplayOrder()) {
+                DROPDOWN -> SurveyDropDownQuestion(answers = surveyQuestion.answers) {
                     onChooseAnswer(surveyQuestion.id, it)
                 }
                 SMILEY, THUMBS -> if (surveyQuestion.answers.size >= NUMBER_OF_EMOJI_ANSWERS) {
                     SurveyEmojiQuestion(
-                        answers = surveyQuestion.answers.sortedByDisplayOrder(),
+                        answers = surveyQuestion.answers,
                         questionDisplayType = surveyQuestion.questionDisplayType
                     ) {
                         onChooseAnswer(surveyQuestion.id, it)

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/UnitTestConstants.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/UnitTestConstants.kt
@@ -3,6 +3,17 @@ package com.kks.nimblesurveyjetpackcompose
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
+import com.kks.nimblesurveyjetpackcompose.model.response.IncludedAnswerResponse
+import com.kks.nimblesurveyjetpackcompose.model.response.IncludedQuestionResponse
+import com.kks.nimblesurveyjetpackcompose.model.response.SurveyDataResponse
+import com.kks.nimblesurveyjetpackcompose.model.response.SurveyIncludedRelationshipsResponse
+import com.kks.nimblesurveyjetpackcompose.model.response.SurveyQuestionsResponse
+
+val surveyAnswer = SurveyAnswer(
+    id = "0",
+    text = "text",
+    displayOrder = 0
+)
 
 val surveyQuestion = SurveyQuestion(
     id = "0",
@@ -11,15 +22,32 @@ val surveyQuestion = SurveyQuestion(
     shortText = "",
     pick = "none",
     questionDisplayType = QuestionDisplayType.NONE,
-    answers = listOf(
-        SurveyAnswer(
-            id = "0",
-            text = "text",
-            displayOrder = 0
-        )
-    )
+    answers = listOf(surveyAnswer)
 )
+
 val surveyQuestions = listOf(
     surveyQuestion,
     surveyQuestion.copy(id = "1", title = "title")
 )
+
+val surveyAnswerDataResponse = SurveyDataResponse(id = "0", type = "answer")
+
+val attributeQuestionResponse =
+    IncludedQuestionResponse.AttributeQuestionResponse(displayType = "intro", displayOrder = 0)
+
+val includedQuestionResponse = IncludedQuestionResponse(
+    id = "0",
+    relationships = SurveyIncludedRelationshipsResponse(
+        answers = SurveyQuestionsResponse(
+            data = listOf(
+                surveyAnswerDataResponse,
+                surveyAnswerDataResponse.copy(id = "1")
+            )
+        )
+    ),
+    attributes = attributeQuestionResponse
+)
+
+val attributeAnswerResponse = IncludedAnswerResponse.AttributeAnswerResponse(displayOrder = 0)
+
+val includedAnswerResponse = IncludedAnswerResponse(id = "0", attributes = attributeAnswerResponse)

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImplTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImplTest.kt
@@ -1,0 +1,154 @@
+package com.kks.nimblesurveyjetpackcompose.repo.survey
+
+import com.google.common.truth.Truth.assertThat
+import com.kks.nimblesurveyjetpackcompose.attributeAnswerResponse
+import com.kks.nimblesurveyjetpackcompose.attributeQuestionResponse
+import com.kks.nimblesurveyjetpackcompose.includedAnswerResponse
+import com.kks.nimblesurveyjetpackcompose.includedQuestionResponse
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
+import com.kks.nimblesurveyjetpackcompose.model.ResourceState
+import com.kks.nimblesurveyjetpackcompose.model.request.SubmitSurveyRequest
+import com.kks.nimblesurveyjetpackcompose.model.response.BaseResponse
+import com.kks.nimblesurveyjetpackcompose.model.response.SurveyIncludedRelationshipsResponse
+import com.kks.nimblesurveyjetpackcompose.model.toSurveyQuestionRequest
+import com.kks.nimblesurveyjetpackcompose.network.Api
+import com.kks.nimblesurveyjetpackcompose.surveyAnswer
+import com.kks.nimblesurveyjetpackcompose.surveyQuestion
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SurveyRepoImplTest {
+
+    val api: Api = mockk()
+    lateinit var sut: SurveyRepoImpl
+
+    @Before
+    fun setup() {
+        sut = SurveyRepoImpl(api)
+    }
+
+    @Test
+    fun `When getSurveyDetail and return success`() = runTest {
+        coEvery { api.getSurveyDetail(any()) } returns BaseResponse(
+            included = listOf(
+                includedQuestionResponse,
+                includedAnswerResponse
+            )
+        )
+
+        val expected = sut.getSurveyDetails("0").last()
+
+        assertThat(expected).isInstanceOf(ResourceState.Success::class.java)
+    }
+
+    @Test
+    fun `When getSurveyDetail and return success, question list is in ascending order`() = runTest {
+        coEvery { api.getSurveyDetail(any()) } returns BaseResponse(
+            included = listOf(
+                includedQuestionResponse.copy(
+                    attributes = attributeQuestionResponse.copy(displayOrder = 1),
+                    relationships = SurveyIncludedRelationshipsResponse()
+                ),
+                includedQuestionResponse,
+                includedAnswerResponse
+            )
+        )
+
+        val expected = sut.getSurveyDetails("0").last()
+
+        assertThat(expected).isInstanceOf(ResourceState.Success::class.java)
+        val expectedSuccessData = expected as ResourceState.Success
+
+        val firstQuestion = expectedSuccessData.data.first()
+        assertThat(firstQuestion.displayOrder).isEqualTo(0)
+
+        val secondQuestion = expectedSuccessData.data[1]
+        assertThat(secondQuestion.displayOrder).isEqualTo(1)
+    }
+
+    @Test
+    fun `When getSurveyDetail and return success, answer list is in ascending order`() = runTest {
+        coEvery { api.getSurveyDetail(any()) } returns BaseResponse(
+            included = listOf(
+                includedQuestionResponse.copy(
+                    attributes = attributeQuestionResponse
+                ),
+                includedAnswerResponse.copy(id = "1", attributes = attributeAnswerResponse.copy(displayOrder = 1)),
+                includedAnswerResponse,
+            )
+        )
+
+        val expected = sut.getSurveyDetails("0").last()
+
+        assertThat(expected).isInstanceOf(ResourceState.Success::class.java)
+        val expectedSuccessData = expected as ResourceState.Success
+
+        val firstAnswer = expectedSuccessData.data.first().answers.first()
+        assertThat(firstAnswer.displayOrder).isEqualTo(0)
+
+        val secondAnswer = expectedSuccessData.data.first().answers[1]
+        assertThat(secondAnswer.displayOrder).isEqualTo(1)
+    }
+
+    @Test
+    fun `When getSurveyDetail and return error`() = runTest {
+        coEvery { api.getSurveyDetail(any()) } throws Throwable("Error")
+
+        val expected = sut.getSurveyDetails("0").last()
+
+        assertThat(expected).isInstanceOf(ResourceState.Error::class.java)
+    }
+
+    @Test
+    fun `When submitSurvey for Smiley question, answers with null is submitted`() = runTest {
+        val smileyQuestion = surveyQuestion.copy(
+            questionDisplayType = QuestionDisplayType.SMILEY,
+            answers = listOf(surveyAnswer.copy(selected = true))
+        )
+
+        sut.submitSurvey(surveyId = "0", surveyQuestions = listOf(smileyQuestion)).collect()
+
+        val expected = smileyQuestion.toSurveyQuestionRequest()
+        assertThat(expected.answers.first().answer).isNull()
+
+        coVerify { api.submitSurvey(SubmitSurveyRequest(surveyId = "0", questions = listOf(expected))) }
+    }
+
+    @Test
+    fun `When submitSurvey for DropDown question, answers with null is submitted`() = runTest {
+        val dropdownQuestion = surveyQuestion.copy(
+            questionDisplayType = QuestionDisplayType.DROPDOWN,
+            answers = listOf(surveyAnswer.copy(selected = true))
+        )
+
+        sut.submitSurvey(surveyId = "0", surveyQuestions = listOf(dropdownQuestion)).collect()
+
+        val expected = dropdownQuestion.toSurveyQuestionRequest()
+        assertThat(expected.answers.first().answer).isNull()
+
+        coVerify { api.submitSurvey(SubmitSurveyRequest(surveyId = "0", questions = listOf(expected))) }
+    }
+
+    @Test
+    fun `When submitSurvey for Thumbs question, answers with null is submitted`() = runTest {
+        val thumbsQuestion = surveyQuestion.copy(
+            questionDisplayType = QuestionDisplayType.THUMBS,
+            answers = listOf(surveyAnswer.copy(selected = true))
+        )
+
+        sut.submitSurvey(surveyId = "0", surveyQuestions = listOf(thumbsQuestion)).collect()
+
+        val expected = thumbsQuestion.toSurveyQuestionRequest()
+        assertThat(expected.answers.first().answer).isNull()
+
+        coVerify { api.submitSurvey(SubmitSurveyRequest(surveyId = "0", questions = listOf(expected))) }
+    }
+}

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -27,4 +27,5 @@ object Versions {
     const val RETROFIT = "2.9.0"
     const val TURBINE = "0.9.0"
     const val TIMBER = "5.0.1"
+    const val TRUTH = "1.1.3"
 }


### PR DESCRIPTION
Closes #33 #34 

## What happened 👀

For Thumbs Rating questions, users can rate their satisfaction by tapping on the 👍  emoji. This works like a normal rating from 1-5 stars question, but we will use 👍 emojis instead of stars

## Acceptance Criteria
When tapping the Next button (or the Submit button) on a Thumbs Rating question, store the currently selected option,
```
{
  "id": "{{question-id}}",
  "answers": [
    {
      "id": "{{selected-answer-id}}"
    }
  ]
}
```
## Insight 📝

Integration for `Thumbs` question is the same as `Smiley` question.

## Proof Of Work 📹


https://user-images.githubusercontent.com/32578035/191037519-02afc4ad-60aa-42e0-9684-e5111a5a2ba9.mp4


