### PR TITLE
[#100] Chore replace catching logic with extension

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepoImpl.kt
@@ -9,6 +9,7 @@ import com.kks.nimblesurveyjetpackcompose.model.response.UserResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.toSurvey
 import com.kks.nimblesurveyjetpackcompose.network.Api
 import com.kks.nimblesurveyjetpackcompose.util.extensions.SUCCESS_WITH_NULL_ERROR
+import com.kks.nimblesurveyjetpackcompose.util.extensions.catchError
 import com.kks.nimblesurveyjetpackcompose.util.extensions.safeApiCall
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -40,9 +41,7 @@ class HomeRepoImpl @Inject constructor(
             is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))
             else -> emit(ResourceState.NetworkError)
         }
-    }.catch { error ->
-        emit(ResourceState.Error(error.message.orEmpty()))
-    }
+    }.catchError()
 
     override fun fetchUserDetail(): Flow<ResourceState<UserResponse>> =
         flow {
@@ -57,9 +56,7 @@ class HomeRepoImpl @Inject constructor(
                 is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))
                 else -> emit(ResourceState.NetworkError)
             }
-        }.catch { error ->
-            emit(ResourceState.Error(error.message.orEmpty()))
-        }
+        }.catchError()
 
     override fun getSurveyListFromDb(): Flow<List<Survey>> =
         surveyDao.getSurveys().transform { value: List<SurveyEntity> -> emit(value.map { it.toSurvey() }) }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/login/LoginRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/login/LoginRepoImpl.kt
@@ -51,7 +51,5 @@ class LoginRepoImpl @Inject constructor(
             is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))
             else -> emit(ResourceState.NetworkError)
         }
-    }.catch { error ->
-        emit(ResourceState.Error(error.message.orEmpty()))
-    }
+    }.catchError()
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImpl.kt
@@ -11,6 +11,7 @@ import com.kks.nimblesurveyjetpackcompose.model.response.toSurveyQuestion
 import com.kks.nimblesurveyjetpackcompose.model.sortedByDisplayOrder
 import com.kks.nimblesurveyjetpackcompose.model.toSurveyQuestionRequest
 import com.kks.nimblesurveyjetpackcompose.network.Api
+import com.kks.nimblesurveyjetpackcompose.util.extensions.catchError
 import com.kks.nimblesurveyjetpackcompose.util.extensions.safeApiCall
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -47,9 +48,7 @@ class SurveyRepoImpl @Inject constructor(@ServiceQualifier private val api: Api)
                 is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))
                 else -> emit(ResourceState.NetworkError)
             }
-        }.catch { error ->
-            emit(ResourceState.Error(error.message.orEmpty()))
-        }
+        }.catchError()
 
     override fun submitSurvey(surveyId: String, surveyQuestions: List<SurveyQuestion>): Flow<ResourceState<Unit>> =
         flow {
@@ -64,9 +63,7 @@ class SurveyRepoImpl @Inject constructor(@ServiceQualifier private val api: Api)
                 is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))
                 else -> emit(ResourceState.NetworkError)
             }
-        }.catch { error ->
-            emit(ResourceState.Error(error.message.orEmpty()))
-        }
+        }.catchError()
 }
 
 private fun List<SurveyQuestion>.toSubmitSurveyRequest(surveyId: String): SubmitSurveyRequest =

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/token/TokenRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/token/TokenRepoImpl.kt
@@ -6,6 +6,7 @@ import com.kks.nimblesurveyjetpackcompose.model.response.LoginResponse
 import com.kks.nimblesurveyjetpackcompose.network.AuthApi
 import com.kks.nimblesurveyjetpackcompose.util.*
 import com.kks.nimblesurveyjetpackcompose.util.extensions.SUCCESS_WITH_NULL_ERROR
+import com.kks.nimblesurveyjetpackcompose.util.extensions.catchError
 import com.kks.nimblesurveyjetpackcompose.util.extensions.safeApiCall
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -48,7 +49,5 @@ class TokenRepoImpl @Inject constructor(
                 ResourceState.NetworkError -> emit(ResourceState.NetworkError)
                 ResourceState.Loading -> emit(ResourceState.Loading)
             }
-        }.catch { error ->
-            emit(ResourceState.Error(error.message.orEmpty()))
-        }
+        }.catchError()
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/AlertDialogs.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/AlertDialogs.kt
@@ -1,7 +1,13 @@
 package com.kks.nimblesurveyjetpackcompose.ui.presentation.common
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,7 +30,15 @@ fun ErrorAlertDialog(
     AlertDialog(
         onDismissRequest = { onClickButton() },
         title = { Text(text = title) },
-        text = { Text(text = if (errorModel.errorType == ErrorType.NETWORK) stringResource(id = R.string.network_error) else errorModel.errorMessage.orEmpty()) },
+        text = {
+            Text(
+                text = if (errorModel.errorType == ErrorType.NETWORK) {
+                    stringResource(id = R.string.network_error)
+                } else {
+                    errorModel.errorMessage.orEmpty()
+                }
+            )
+        },
         backgroundColor = Color.White,
         confirmButton = {
             Box(

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/AlertDialogs.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/AlertDialogs.kt
@@ -6,8 +6,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.model.ErrorModel
 import com.kks.nimblesurveyjetpackcompose.ui.theme.CuriousBlue
 import com.kks.nimblesurveyjetpackcompose.util.extensions.ErrorType
@@ -22,7 +24,7 @@ fun ErrorAlertDialog(
     AlertDialog(
         onDismissRequest = { onClickButton() },
         title = { Text(text = title) },
-        text = { Text(text = errorModel.errorMessage.orEmpty()) },
+        text = { Text(text = if (errorModel.errorType == ErrorType.NETWORK) stringResource(id = R.string.network_error) else errorModel.errorMessage.orEmpty()) },
         backgroundColor = Color.White,
         confirmButton = {
             Box(

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/util/extensions/NetworkExtension.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/util/extensions/NetworkExtension.kt
@@ -4,11 +4,17 @@ package com.kks.nimblesurveyjetpackcompose.util.extensions
 
 import com.kks.nimblesurveyjetpackcompose.model.ErrorModel
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
+import com.kks.nimblesurveyjetpackcompose.model.response.BaseResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.CustomErrorResponse
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import retrofit2.HttpException
 import retrofit2.Response
 import java.io.IOException
@@ -70,3 +76,8 @@ fun <T> ResourceState<T>.mapError(): ErrorModel? {
 enum class ErrorType {
     INFO, NETWORK
 }
+
+fun <T> Flow<ResourceState<T>>.catchError() =
+    catch { error ->
+        emit(ResourceState.Error(error.message.orEmpty()))
+    }


### PR DESCRIPTION
Closes #100 

## What happened 👀

Currently catching flow is working but repeating codes. Create an extension to catch the flow and avoid boilerplate code. Replace the with the extension.

## Insight 📝

- Replace every `flow catch` with extension `catchError`
- Fix blank error text showing when there is a network error

## Proof Of Work 📹

Still catching the error:
https://user-images.githubusercontent.com/32578035/191212936-94727866-10d2-4b48-8a8c-4f8651a2b915.mp4
