### PR TITLE
[#35] [#36] Integrate star survey question

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -17,7 +17,8 @@ enum class QuestionDisplayType(val typeValue: String, val isIdOnlyAnswer: Boolea
     INTRO("intro", false),
     DROPDOWN("dropdown", true),
     SMILEY("smiley", true),
-    THUMBS("thumbs", true)
+    THUMBS("thumbs", true),
+    STARS("star", true)
 }
 
 fun List<SurveyQuestion>.sortedByDisplayOrder(): List<SurveyQuestion> = this.sortedBy { it.displayOrder }
@@ -35,5 +36,7 @@ fun String.getQuestionDisplayType() =
         QuestionDisplayType.INTRO.typeValue -> QuestionDisplayType.INTRO
         QuestionDisplayType.DROPDOWN.typeValue -> QuestionDisplayType.DROPDOWN
         QuestionDisplayType.SMILEY.typeValue -> QuestionDisplayType.SMILEY
+        QuestionDisplayType.STARS.typeValue -> QuestionDisplayType.STARS
+        QuestionDisplayType.THUMBS.typeValue -> QuestionDisplayType.THUMBS
         else -> QuestionDisplayType.NONE
     }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestion.kt
@@ -16,11 +16,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.SMILEY
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.STARS
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.THUMBS
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.ui.theme.Black50
 
 private val SMILEY_EMOJIS = listOf("😡", "😕", "😐", "🙂", "😄")
+private val STARS_EMOJIS = listOf("⭐", "⭐", "⭐", "⭐", "⭐")
 private val THUMBS_EMOJIS = listOf("\uD83D\uDC4D", "\uD83D\uDC4D", "\uD83D\uDC4D", "\uD83D\uDC4D", "\uD83D\uDC4D")
 
 @Composable
@@ -35,6 +37,7 @@ fun SurveyEmojiQuestion(
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
         when (questionDisplayType) {
             SMILEY -> SMILEY_EMOJIS
+            STARS -> STARS_EMOJIS
             THUMBS -> THUMBS_EMOJIS
             else -> emptyList()
         }.forEachIndexed { index, text ->

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -16,6 +16,7 @@ import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.DROPDOWN
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.NONE
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.SMILEY
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.STARS
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.THUMBS
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.model.SurveyQuestion
@@ -51,6 +52,7 @@ fun SurveyQuestionScreen(
                     onChooseAnswer(surveyQuestion.id, it)
                 }
                 SMILEY,
+                STARS,
                 THUMBS -> if (surveyQuestion.answers.size >= NUMBER_OF_EMOJI_ANSWERS) {
                     SurveyEmojiQuestion(
                         answers = surveyQuestion.answers,

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImplTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImplTest.kt
@@ -5,7 +5,10 @@ import com.kks.nimblesurveyjetpackcompose.attributeAnswerResponse
 import com.kks.nimblesurveyjetpackcompose.attributeQuestionResponse
 import com.kks.nimblesurveyjetpackcompose.includedAnswerResponse
 import com.kks.nimblesurveyjetpackcompose.includedQuestionResponse
-import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.DROPDOWN
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.THUMBS
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.SMILEY
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.STARS
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
 import com.kks.nimblesurveyjetpackcompose.model.request.SubmitSurveyRequest
 import com.kks.nimblesurveyjetpackcompose.model.response.BaseResponse
@@ -27,8 +30,8 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 class SurveyRepoImplTest {
 
-    val api: Api = mockk()
-    lateinit var sut: SurveyRepoImpl
+    private val api: Api = mockk()
+    private lateinit var sut: SurveyRepoImpl
 
     @Before
     fun setup() {
@@ -110,7 +113,7 @@ class SurveyRepoImplTest {
     @Test
     fun `When submitSurvey for Smiley question, answers with null is submitted`() = runTest {
         val smileyQuestion = surveyQuestion.copy(
-            questionDisplayType = QuestionDisplayType.SMILEY,
+            questionDisplayType = SMILEY,
             answers = listOf(surveyAnswer.copy(selected = true))
         )
 
@@ -125,7 +128,7 @@ class SurveyRepoImplTest {
     @Test
     fun `When submitSurvey for DropDown question, answers with null is submitted`() = runTest {
         val dropdownQuestion = surveyQuestion.copy(
-            questionDisplayType = QuestionDisplayType.DROPDOWN,
+            questionDisplayType = DROPDOWN,
             answers = listOf(surveyAnswer.copy(selected = true))
         )
 
@@ -140,7 +143,22 @@ class SurveyRepoImplTest {
     @Test
     fun `When submitSurvey for Thumbs question, answers with null is submitted`() = runTest {
         val thumbsQuestion = surveyQuestion.copy(
-            questionDisplayType = QuestionDisplayType.THUMBS,
+            questionDisplayType = THUMBS,
+            answers = listOf(surveyAnswer.copy(selected = true))
+        )
+
+        sut.submitSurvey(surveyId = "0", surveyQuestions = listOf(thumbsQuestion)).collect()
+
+        val expected = thumbsQuestion.toSurveyQuestionRequest()
+        assertThat(expected.answers.first().answer).isNull()
+
+        coVerify { api.submitSurvey(SubmitSurveyRequest(surveyId = "0", questions = listOf(expected))) }
+    }
+
+    @Test
+    fun `When submitSurvey for Star question, answers with null is submitted`() = runTest {
+        val thumbsQuestion = surveyQuestion.copy(
+            questionDisplayType = STARS,
             answers = listOf(surveyAnswer.copy(selected = true))
         )
 


### PR DESCRIPTION
Closes #35 #36 

## What happened 👀

When a Question model has display_type as star,

- Display an Emoji Rating question with ⭐️ as the options
- The number of stars (⭐️) must match with the number of answers
- By default, none are initially selected

When tapping the Next button (or the Submit button) on a Star Rating question, store the currently selected option,
```
{
  "id": "{{question-id}}",
  "answers": [
    {
      "id": "{{selected-answer-id}}"
    }
  ]
}
```

## Insight 📝

- Integrate survey questions for ⭐ emoji
- Integration for ⭐ emoji is the same as the other emoji question and already implemented

## Proof Of Work 📹

https://user-images.githubusercontent.com/32578035/191662526-7fef82da-2f38-480f-b3a2-42bb1e308382.mp4


