### PR TITLE
[#103] Fix paging number increasing when api call fails and clearing …

### DIFF
--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
 import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.base.BaseAndroidComposeTest
+import com.kks.nimblesurveyjetpackcompose.model.Meta
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
 import com.kks.nimblesurveyjetpackcompose.repo.home.HomeRepo
 import com.kks.nimblesurveyjetpackcompose.surveys
@@ -57,7 +58,7 @@ class HomeScreenTest : BaseAndroidComposeTest() {
     @Test
     fun when_get_survey_list_is_successful_show_first_survey() {
         with(composeTestRule) {
-            every { homeRepo.fetchSurveyList(any(), any(), any()) } returns flowOf(ResourceState.Success(Unit))
+            every { homeRepo.fetchSurveyList(any(), any(), any()) } returns flowOf(ResourceState.Success(Meta()))
             every { homeRepo.getSurveyListFromDb() } returns flowOf(surveys)
             setupHomeComposeRule()
             onNodeWithText(surveys.first().title).assertIsDisplayed()
@@ -69,7 +70,7 @@ class HomeScreenTest : BaseAndroidComposeTest() {
     @Test
     fun when_swipe_show_next_survey() {
         with(composeTestRule) {
-            every { homeRepo.fetchSurveyList(any(), any(), any()) } returns flowOf(ResourceState.Success(Unit))
+            every { homeRepo.fetchSurveyList(any(), any(), any()) } returns flowOf(ResourceState.Success(Meta()))
             every { homeRepo.getSurveyListFromDb() } returns flowOf(surveys)
             setupHomeComposeRule()
             onNodeWithContentDescription(getString(R.string.home_survey_content)).performTouchInput {

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/Meta.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/Meta.kt
@@ -1,0 +1,9 @@
+package com.kks.nimblesurveyjetpackcompose.model
+
+data class Meta(
+    val page: Int = 0,
+    val pages: Int = 0,
+    val pageSize: Int = 0,
+    val records: Int = 0,
+    val message: String = ""
+)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/MetaResponse.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/MetaResponse.kt
@@ -18,10 +18,10 @@ data class MetaResponse(
     val message: String?
 )
 
-fun MetaResponse.toMeta() = Meta(
-    page = page ?: 0,
-    pages = pages ?: 0,
-    pageSize = pageSize ?: 0,
-    records = records ?: 0,
-    message = message.orEmpty()
+fun MetaResponse?.toMeta() = Meta(
+    page = this?.page ?: 0,
+    pages = this?.pages ?: 0,
+    pageSize = this?.pageSize ?: 0,
+    records = this?.records ?: 0,
+    message = this?.message.orEmpty()
 )

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/MetaResponse.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/response/MetaResponse.kt
@@ -1,5 +1,6 @@
 package com.kks.nimblesurveyjetpackcompose.model.response
 
+import com.kks.nimblesurveyjetpackcompose.model.Meta
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
@@ -15,4 +16,12 @@ data class MetaResponse(
     val records: Int?,
     @Json(name = "message")
     val message: String?
+)
+
+fun MetaResponse.toMeta() = Meta(
+    page = page ?: 0,
+    pages = pages ?: 0,
+    pageSize = pageSize ?: 0,
+    records = records ?: 0,
+    message = message.orEmpty()
 )

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepo.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepo.kt
@@ -1,7 +1,9 @@
 package com.kks.nimblesurveyjetpackcompose.repo.home
 
+import com.kks.nimblesurveyjetpackcompose.model.Meta
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
 import com.kks.nimblesurveyjetpackcompose.model.Survey
+import com.kks.nimblesurveyjetpackcompose.model.response.MetaResponse
 import com.kks.nimblesurveyjetpackcompose.model.response.UserResponse
 import kotlinx.coroutines.flow.Flow
 
@@ -9,9 +11,8 @@ interface HomeRepo {
     fun fetchSurveyList(
         pageNumber: Int,
         pageSize: Int,
-        getNumberOfPage: (totalPage: Int) -> Unit
-    ): Flow<ResourceState<Unit>>
+        clearCache: Boolean
+    ): Flow<ResourceState<Meta>>
     fun fetchUserDetail(): Flow<ResourceState<UserResponse>>
     fun getSurveyListFromDb(): Flow<List<Survey>>
-    suspend fun clearSurveyList()
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepo.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepo.kt
@@ -11,7 +11,7 @@ interface HomeRepo {
     fun fetchSurveyList(
         pageNumber: Int,
         pageSize: Int,
-        clearCache: Boolean
+        isClearCache: Boolean
     ): Flow<ResourceState<Meta>>
     fun fetchUserDetail(): Flow<ResourceState<UserResponse>>
     fun getSurveyListFromDb(): Flow<List<Survey>>

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepoImpl.kt
@@ -27,14 +27,14 @@ class HomeRepoImpl @Inject constructor(
     override fun fetchSurveyList(
         pageNumber: Int,
         pageSize: Int,
-        clearCache: Boolean
+        isClearCache: Boolean
     ): Flow<ResourceState<Meta>> = flow {
         emit(ResourceState.Loading)
         val apiResult = safeApiCall(Dispatchers.IO) { apiInterface.getSurveyList(pageNumber, pageSize) }
         when (apiResult) {
             is ResourceState.Success -> {
                 apiResult.data.data?.let { surveyResponseList ->
-                    if (clearCache) surveyDao.clearSurveys()
+                    if (isClearCache) surveyDao.clearSurveys()
                     surveyDao.addSurveys(surveyResponseList.map { it.toSurvey() })
                 }
                 emit(ResourceState.Success(apiResult.data.meta?.toMeta() ?: Meta()))

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepoImpl.kt
@@ -1,11 +1,13 @@
 package com.kks.nimblesurveyjetpackcompose.repo.home
 
 import com.kks.nimblesurveyjetpackcompose.cache.SurveyDao
+import com.kks.nimblesurveyjetpackcompose.model.Meta
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
 import com.kks.nimblesurveyjetpackcompose.model.Survey
 import com.kks.nimblesurveyjetpackcompose.model.entities.SurveyEntity
 import com.kks.nimblesurveyjetpackcompose.model.entities.toSurvey
 import com.kks.nimblesurveyjetpackcompose.model.response.UserResponse
+import com.kks.nimblesurveyjetpackcompose.model.response.toMeta
 import com.kks.nimblesurveyjetpackcompose.model.response.toSurvey
 import com.kks.nimblesurveyjetpackcompose.network.Api
 import com.kks.nimblesurveyjetpackcompose.util.extensions.SUCCESS_WITH_NULL_ERROR
@@ -13,7 +15,6 @@ import com.kks.nimblesurveyjetpackcompose.util.extensions.catchError
 import com.kks.nimblesurveyjetpackcompose.util.extensions.safeApiCall
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.transform
 import javax.inject.Inject
@@ -26,17 +27,17 @@ class HomeRepoImpl @Inject constructor(
     override fun fetchSurveyList(
         pageNumber: Int,
         pageSize: Int,
-        getNumberOfPage: (totalPage: Int) -> Unit
-    ): Flow<ResourceState<Unit>> = flow {
+        clearCache: Boolean
+    ): Flow<ResourceState<Meta>> = flow {
         emit(ResourceState.Loading)
         val apiResult = safeApiCall(Dispatchers.IO) { apiInterface.getSurveyList(pageNumber, pageSize) }
         when (apiResult) {
             is ResourceState.Success -> {
                 apiResult.data.data?.let { surveyResponseList ->
+                    if (clearCache) surveyDao.clearSurveys()
                     surveyDao.addSurveys(surveyResponseList.map { it.toSurvey() })
-                    getNumberOfPage(apiResult.data.meta?.pages ?: 0)
                 }
-                emit(ResourceState.Success(Unit))
+                emit(ResourceState.Success(apiResult.data.meta?.toMeta() ?: Meta()))
             }
             is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))
             else -> emit(ResourceState.NetworkError)
@@ -60,6 +61,4 @@ class HomeRepoImpl @Inject constructor(
 
     override fun getSurveyListFromDb(): Flow<List<Survey>> =
         surveyDao.getSurveys().transform { value: List<SurveyEntity> -> emit(value.map { it.toSurvey() }) }
-
-    override suspend fun clearSurveyList() = surveyDao.clearSurveys()
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepoImpl.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/repo/home/HomeRepoImpl.kt
@@ -37,7 +37,7 @@ class HomeRepoImpl @Inject constructor(
                     if (isClearCache) surveyDao.clearSurveys()
                     surveyDao.addSurveys(surveyResponseList.map { it.toSurvey() })
                 }
-                emit(ResourceState.Success(apiResult.data.meta?.toMeta() ?: Meta()))
+                emit(ResourceState.Success(apiResult.data.meta.toMeta()))
             }
             is ResourceState.Error -> emit(ResourceState.Error(apiResult.error))
             else -> emit(ResourceState.NetworkError)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/home/HomeScreen.kt
@@ -90,7 +90,7 @@ fun HomeScreen(navigator: DestinationsNavigator, viewModel: HomeViewModel = hilt
             if (isRefreshing && surveyList.isEmpty()) {
                 item { HomeScreenShimmerLoading(modifier = Modifier.fillParentMaxSize()) }
             }
-            if (surveyList.isNotEmpty() && error == null) {
+            if (surveyList.isNotEmpty()) {
                 item {
                     LaunchedEffect(keys = arrayOf(swipeableState.offset.value), block = {
                         val currentSwipeState = swipeableState.offset.value

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModel.kt
@@ -87,7 +87,7 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch(ioDispatcher) {
             _pages = DEFAULT_PAGES
             _selectedSurveyNumber.value = START_SURVEY_NUMBER
-            getSurveyList(clearCache = true)
+            getSurveyList(isClearCache = true)
         }
     }
 
@@ -100,14 +100,14 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun getSurveyList(clearCache: Boolean = false) {
-        val pageNumber = ((if (clearCache) START_SURVEY_NUMBER else _surveyList.value.size) / DEFAULT_PAGE_SIZE) + 1
-        if ((pageNumber <= _pages && _surveyList.value.size < _records) || clearCache) {
+    private fun getSurveyList(isClearCache: Boolean = false) {
+        val pageNumber = ((if (isClearCache) START_SURVEY_NUMBER else _surveyList.value.size) / DEFAULT_PAGE_SIZE) + 1
+        if ((pageNumber <= _pages && _surveyList.value.size < _records) || isClearCache) {
             viewModelScope.launch(ioDispatcher) {
                 homeRepo.fetchSurveyList(
                     pageNumber = pageNumber,
                     pageSize = DEFAULT_PAGE_SIZE,
-                    clearCache = clearCache
+                    isClearCache = isClearCache
                 ).collect { result ->
                     when (result) {
                         is ResourceState.Loading -> {

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModel.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModel.kt
@@ -30,7 +30,7 @@ class HomeViewModel @Inject constructor(
     private val _isRefreshing = MutableStateFlow(false)
     private val _surveyList = MutableStateFlow<List<Survey>>(listOf())
     private val _userAvatar = MutableStateFlow<String?>(null)
-    private var _pages = DEFAULT_PAGES
+    private var _pageCount = DEFAULT_PAGES
     private var _records = DEFAULT_PAGES
     private val _selectedSurveyNumber = MutableStateFlow(START_SURVEY_NUMBER)
 
@@ -85,7 +85,7 @@ class HomeViewModel @Inject constructor(
 
     fun clearCacheAndFetch() {
         viewModelScope.launch(ioDispatcher) {
-            _pages = DEFAULT_PAGES
+            _pageCount = DEFAULT_PAGES
             _selectedSurveyNumber.value = START_SURVEY_NUMBER
             getSurveyList(isClearCache = true)
         }
@@ -101,11 +101,11 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun getSurveyList(isClearCache: Boolean = false) {
-        val pageNumber = ((if (isClearCache) START_SURVEY_NUMBER else _surveyList.value.size) / DEFAULT_PAGE_SIZE) + 1
-        if ((pageNumber <= _pages && _surveyList.value.size < _records) || isClearCache) {
+        val currentPage = ((if (isClearCache) START_SURVEY_NUMBER else _surveyList.value.size) / DEFAULT_PAGE_SIZE) + 1
+        if ((currentPage <= _pageCount && _surveyList.value.size < _records) || isClearCache) {
             viewModelScope.launch(ioDispatcher) {
                 homeRepo.fetchSurveyList(
-                    pageNumber = pageNumber,
+                    pageNumber = currentPage,
                     pageSize = DEFAULT_PAGE_SIZE,
                     isClearCache = isClearCache
                 ).collect { result ->
@@ -115,7 +115,7 @@ class HomeViewModel @Inject constructor(
                             resetError()
                         }
                         is ResourceState.Success -> {
-                            this@HomeViewModel._pages = result.data.pages
+                            this@HomeViewModel._pageCount = result.data.pages
                             this@HomeViewModel._records = result.data.records
                             _isRefreshing.value = false
                             resetError()

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.kks.nimblesurveyjetpackcompose.viewmodel.home
 
 import com.kks.nimblesurveyjetpackcompose.base.BaseViewModelTest
+import com.kks.nimblesurveyjetpackcompose.model.Meta
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
 import com.kks.nimblesurveyjetpackcompose.model.Survey
 import com.kks.nimblesurveyjetpackcompose.repo.home.HomeRepo
@@ -11,13 +12,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.Test
 import org.junit.Assert.assertEquals
+import org.junit.Test
 
 @ExperimentalCoroutinesApi
 class HomeViewModelTest : BaseViewModelTest() {
     private lateinit var viewModel: HomeViewModel
     private val homeRepo: HomeRepo = mockk()
+    private val survey: Survey = mockk()
 
     override fun setup() {
         super.setup()
@@ -27,7 +29,13 @@ class HomeViewModelTest : BaseViewModelTest() {
     @Test
     fun `When view model is created, survey list with pageNumber 1 is fetched`() = runTest {
         advanceUntilIdle()
-        verify { homeRepo.fetchSurveyList(pageNumber = 1, pageSize = any(), getNumberOfPage = any()) }
+        verify {
+            homeRepo.fetchSurveyList(
+                pageNumber = 1,
+                pageSize = any(),
+                clearCache = false
+            )
+        }
     }
 
     @Test
@@ -45,7 +53,13 @@ class HomeViewModelTest : BaseViewModelTest() {
     @Test
     fun `When survey list is fetched from remote and return error, error dialog is shown`() = runTest {
         val errorMessage = "error"
-        every { homeRepo.fetchSurveyList(any(), any(), any()) } returns flowOf(ResourceState.Error(errorMessage))
+        every {
+            homeRepo.fetchSurveyList(
+                pageNumber = any(),
+                pageSize = any(),
+                clearCache = any()
+            )
+        } returns flowOf(ResourceState.Error(errorMessage))
 
         advanceUntilIdle()
         assertEquals(viewModel.error.value?.errorMessage, errorMessage)
@@ -57,9 +71,9 @@ class HomeViewModelTest : BaseViewModelTest() {
             homeRepo.fetchSurveyList(
                 pageSize = any(),
                 pageNumber = any(),
-                getNumberOfPage = any()
+                clearCache = any()
             )
-        } returns flowOf(ResourceState.Success(Unit))
+        } returns flowOf(ResourceState.Success(Meta()))
 
         advanceUntilIdle()
         assertEquals(viewModel.surveyList.value, emptyList<Survey>())
@@ -68,12 +82,26 @@ class HomeViewModelTest : BaseViewModelTest() {
     @Test
     fun `When next page of survey list is fetched, survey list is called with incremented pageNumber`() = runTest {
         every { homeRepo.fetchUserDetail() } returns flowOf(ResourceState.Loading)
-        every { homeRepo.getSurveyListFromDb() } returns flowOf(emptyList())
-        every { homeRepo.fetchSurveyList(any(), any(), any()) } returns flowOf(ResourceState.Loading)
+        every { homeRepo.getSurveyListFromDb() } returns flowOf(List(5) { survey })
+        every {
+            homeRepo.fetchSurveyList(
+                pageNumber = any(),
+                pageSize = any(),
+                clearCache = any()
+            )
+        } returns flowOf(ResourceState.Success(Meta(pages = 2, records = 10)))
+
+        advanceUntilIdle()
 
         viewModel.getNextPage()
 
         advanceUntilIdle()
-        verify { homeRepo.fetchSurveyList(pageNumber = 2, pageSize = any(), getNumberOfPage = any()) }
+        verify {
+            homeRepo.fetchSurveyList(
+                pageNumber = 2,
+                pageSize = any(),
+                clearCache = false
+            )
+        }
     }
 }

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/viewmodel/home/HomeViewModelTest.kt
@@ -33,7 +33,7 @@ class HomeViewModelTest : BaseViewModelTest() {
             homeRepo.fetchSurveyList(
                 pageNumber = 1,
                 pageSize = any(),
-                clearCache = false
+                isClearCache = false
             )
         }
     }
@@ -57,7 +57,7 @@ class HomeViewModelTest : BaseViewModelTest() {
             homeRepo.fetchSurveyList(
                 pageNumber = any(),
                 pageSize = any(),
-                clearCache = any()
+                isClearCache = any()
             )
         } returns flowOf(ResourceState.Error(errorMessage))
 
@@ -71,7 +71,7 @@ class HomeViewModelTest : BaseViewModelTest() {
             homeRepo.fetchSurveyList(
                 pageSize = any(),
                 pageNumber = any(),
-                clearCache = any()
+                isClearCache = any()
             )
         } returns flowOf(ResourceState.Success(Meta()))
 
@@ -87,7 +87,7 @@ class HomeViewModelTest : BaseViewModelTest() {
             homeRepo.fetchSurveyList(
                 pageNumber = any(),
                 pageSize = any(),
-                clearCache = any()
+                isClearCache = any()
             )
         } returns flowOf(ResourceState.Success(Meta(pages = 2, records = 10)))
 
@@ -100,7 +100,7 @@ class HomeViewModelTest : BaseViewModelTest() {
             homeRepo.fetchSurveyList(
                 pageNumber = 2,
                 pageSize = any(),
-                clearCache = false
+                isClearCache = false
             )
         }
     }


### PR DESCRIPTION
Closes #103 

## What happened 👀

On Home Screen, when api call is failed, pagination is still increasing and thus api call doesn't call anymore when connection is restored. Also when pull to refresh and api call failed, the cache is cleared before the api call is a success.

## Insight 📝

- Refactor fetching logic to be based on the total number of records instead of hard code `pageNumber`
- Fix some test classes

## Proof Of Work 📹

https://user-images.githubusercontent.com/32578035/191726479-87bfcb04-d6c1-431c-b714-58ea410e6528.mp4



