### PR TITLE
[#37] [UI] As a user, I can see an NPS question

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -304,7 +304,13 @@ fun NextQuestionButton(
 @Composable
 fun SurveyDetailStartScreen(survey: Survey, modifier: Modifier = Modifier) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        SurveyBoldText(text = survey.title, fontSize = 28.sp, modifier = Modifier.padding(horizontal = 20.dp))
+        SurveyBoldText(
+            text = survey.title,
+            fontSize = 28.sp,
+            modifier = Modifier
+                .padding(horizontal = 20.dp)
+                .fillMaxWidth()
+        )
         Text(
             text = survey.description,
             fontFamily = NeuzeitFamily,
@@ -325,7 +331,8 @@ fun SurveyBoldText(
     modifier: Modifier = Modifier,
     color: Color = Color.White,
     maxLines: Int = Int.MAX_VALUE,
-    overflow: TextOverflow = TextOverflow.Clip
+    overflow: TextOverflow = TextOverflow.Clip,
+    textAlign: TextAlign? = null
 ) {
     Text(
         text = text,
@@ -334,8 +341,9 @@ fun SurveyBoldText(
         color = color,
         fontSize = fontSize,
         maxLines = maxLines,
-        modifier = modifier.fillMaxWidth(),
-        overflow = overflow
+        modifier = modifier,
+        overflow = overflow,
+        textAlign = textAlign
     )
 }
 

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNPSScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNPSScreen.kt
@@ -1,0 +1,112 @@
+package com.kks.nimblesurveyjetpackcompose.ui.presentation.survey
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstraintLayout
+import com.kks.nimblesurveyjetpackcompose.R
+import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
+import com.kks.nimblesurveyjetpackcompose.ui.theme.White50
+
+private const val START_INDEX = 0
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun SurveyNPSQuestion(
+    answers: List<SurveyAnswer>,
+    onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit
+) {
+    var selectedIndex by remember { mutableStateOf(answers.indexOfFirst { it.selected }) }
+
+    ConstraintLayout(modifier = Modifier.wrapContentWidth()) {
+        val (nps, notAtAll, extremely) = createRefs()
+        Row(
+            modifier = Modifier
+                .constrainAs(nps) {
+                    start.linkTo(parent.start, 20.dp)
+                    end.linkTo(parent.end, 20.dp)
+                    top.linkTo(parent.top)
+                },
+            horizontalArrangement = Arrangement.Center
+        ) {
+            answers.forEachIndexed { index, surveyAnswer ->
+                Box(contentAlignment = Alignment.Center) {
+                    Surface(
+                        onClick = {
+                            selectedIndex = index
+                            onChooseAnswer(
+                                answers.mapIndexed { index, surveyAnswer ->
+                                    surveyAnswer.copy(selected = index == selectedIndex)
+                                }
+                            )
+                        },
+                        border = BorderStroke(0.5.dp, Color.White),
+                        shape = RoundedCornerShape(
+                            topStart = if (index == START_INDEX) 10.dp else 0.dp,
+                            bottomStart = if (index == START_INDEX) 10.dp else 0.dp,
+                            topEnd = if (index == answers.size - 1) 10.dp else 0.dp,
+                            bottomEnd = if (index == answers.size - 1) 10.dp else 0.dp
+                        ),
+                        color = Color.Transparent,
+                        modifier = Modifier.size(33.dp, 56.dp)
+                    ) { /* Do nothing */ }
+
+                    SurveyBoldText(
+                        text = surveyAnswer.text,
+                        color = if (index <= selectedIndex) {
+                            Color.White
+                        } else {
+                            White50
+                        },
+                        fontSize = 20.sp,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        }
+        SurveyBoldText(
+            text = stringResource(id = R.string.survey_question_not_at_all_likely),
+            fontSize = 17.sp,
+            modifier = Modifier.constrainAs(notAtAll) {
+                top.linkTo(nps.bottom)
+                start.linkTo(nps.start)
+            }
+        )
+        SurveyBoldText(
+            text = stringResource(id = R.string.survey_question_extremely_likely),
+            fontSize = 17.sp,
+            modifier = Modifier.constrainAs(extremely) {
+                top.linkTo(nps.bottom)
+                end.linkTo(nps.end)
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0)
+@Composable
+fun PreviewSurveyNPSQuestion() {
+    SurveyNPSQuestion(answers = emptyList()) {
+        // Do nothing
+    }
+}
+

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNPSScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNPSScreen.kt
@@ -31,7 +31,7 @@ private const val START_INDEX = 0
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun SurveyNPSQuestion(
+fun SurveyNpsQuestion(
     answers: List<SurveyAnswer>,
     onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit
 ) {
@@ -63,8 +63,8 @@ fun SurveyNPSQuestion(
                         shape = RoundedCornerShape(
                             topStart = if (index == START_INDEX) 10.dp else 0.dp,
                             bottomStart = if (index == START_INDEX) 10.dp else 0.dp,
-                            topEnd = if (index == answers.size - 1) 10.dp else 0.dp,
-                            bottomEnd = if (index == answers.size - 1) 10.dp else 0.dp
+                            topEnd = if (index == answers.lastIndex) 10.dp else 0.dp,
+                            bottomEnd = if (index == answers.lastIndex) 10.dp else 0.dp
                         ),
                         color = Color.Transparent,
                         modifier = Modifier.size(33.dp, 56.dp)
@@ -89,7 +89,8 @@ fun SurveyNPSQuestion(
             modifier = Modifier.constrainAs(notAtAll) {
                 top.linkTo(nps.bottom)
                 start.linkTo(nps.start)
-            }
+            },
+            color = White50
         )
         SurveyBoldText(
             text = stringResource(id = R.string.survey_question_extremely_likely),
@@ -105,8 +106,7 @@ fun SurveyNPSQuestion(
 @Preview(showBackground = true, backgroundColor = 0)
 @Composable
 fun PreviewSurveyNPSQuestion() {
-    SurveyNPSQuestion(answers = emptyList()) {
+    SurveyNpsQuestion(answers = emptyList()) {
         // Do nothing
     }
 }
-

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -3,6 +3,7 @@ package com.kks.nimblesurveyjetpackcompose.ui.presentation.survey
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -45,7 +46,11 @@ fun SurveyQuestionScreen(
             fontSize = 15.sp,
             color = White50
         )
-        SurveyBoldText(text = surveyQuestion.title, fontSize = 34.sp)
+        SurveyBoldText(
+            text = surveyQuestion.title,
+            fontSize = 34.sp,
+            modifier = Modifier.fillMaxWidth()
+        )
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             when (surveyQuestion.questionDisplayType) {
                 DROPDOWN -> SurveyDropDownQuestion(answers = surveyQuestion.answers) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,6 @@
     <string name="survey_question_next_question">Survey next question</string>
     <string name="survey_question_submit_survey">Submit</string>
     <string name="survey_question_thanks">Thanks for taking\nthe survey.</string>
+    <string name="survey_question_not_at_all_likely">Not at all Likely</string>
+    <string name="survey_question_extremely_likely">Extremely Likely</string>
 </resources>


### PR DESCRIPTION
Closes #37 

## What happened 👀

NPS stands for Net Promoter Score. Users can select their likeliness rating from scale 1-10 to state the likeliness as their answers, e.g. the likeliness of their revisiting the restaurant, the likeliness of them recommending the hotel to friends, etc.

## Insight 📝

- Display the answers on a scale
- Select any option should highlight every other number on its left
- For instance, if a user selects 5, 1-5 should be highlighted.
- Unhighlighted options must be grayed out and unbolded.
- Show the Not at all Likely label on the leftest of the scale
- Show the Extremely Likely label on the rightest of the scale

## Proof Of Work 📹
![Screenshot_20220927_215100](https://user-images.githubusercontent.com/32578035/192691400-225bc189-5dd0-406c-8e1c-45c87b30601a.png)


