### PR TITLE
[#38] [#39] [Integrate] As a user, I can see and answer an NPS question 

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -18,7 +18,8 @@ enum class QuestionDisplayType(val typeValue: String, val isIdOnlyAnswer: Boolea
     DROPDOWN("dropdown", true),
     SMILEY("smiley", true),
     THUMBS("thumbs", true),
-    STARS("star", true)
+    STARS("star", true),
+    NPS("nps", true)
 }
 
 fun List<SurveyQuestion>.sortedByDisplayOrder(): List<SurveyQuestion> = this.sortedBy { it.displayOrder }
@@ -38,5 +39,6 @@ fun String.getQuestionDisplayType() =
         QuestionDisplayType.SMILEY.typeValue -> QuestionDisplayType.SMILEY
         QuestionDisplayType.STARS.typeValue -> QuestionDisplayType.STARS
         QuestionDisplayType.THUMBS.typeValue -> QuestionDisplayType.THUMBS
+        QuestionDisplayType.NPS.typeValue -> QuestionDisplayType.NPS
         else -> QuestionDisplayType.NONE
     }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDropdownQuestionScreen.kt
@@ -37,7 +37,7 @@ import com.kks.nimblesurveyjetpackcompose.ui.theme.Black60
 private const val INVALID_INDEX = -1
 
 @Composable
-fun SurveyDropDownQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit) {
+fun SurveyDropDownQuestionScreen(answers: List<SurveyAnswer>, onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit) {
     val answerIndex = answers.indexOfFirst { it.selected }
     var expanded by remember { mutableStateOf(false) }
     var selectedIndex by remember { mutableStateOf(if (answerIndex == INVALID_INDEX) 0 else answerIndex) }
@@ -100,7 +100,7 @@ fun SurveyDropDownQuestion(answers: List<SurveyAnswer>, onChooseAnswer: (answers
 @Preview(showBackground = true)
 @Composable
 fun SurveyDropDownQuestionPreview() {
-    SurveyDropDownQuestion(listOf()) {
+    SurveyDropDownQuestionScreen(listOf()) {
         // Do nothing
     }
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyEmojiQuestionScreen.kt
@@ -26,7 +26,7 @@ private val STARS_EMOJIS = listOf("⭐", "⭐", "⭐", "⭐", "⭐")
 private val THUMBS_EMOJIS = listOf("\uD83D\uDC4D", "\uD83D\uDC4D", "\uD83D\uDC4D", "\uD83D\uDC4D", "\uD83D\uDC4D")
 
 @Composable
-fun SurveyEmojiQuestion(
+fun SurveyEmojiQuestionScreen(
     answers: List<SurveyAnswer>,
     questionDisplayType: QuestionDisplayType,
     onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit
@@ -66,7 +66,7 @@ fun SurveyEmojiQuestion(
 @Preview(showBackground = true)
 @Composable
 fun PreviewSurveySmileyQuestion() {
-    SurveyEmojiQuestion(answers = emptyList(), questionDisplayType = SMILEY) {
+    SurveyEmojiQuestionScreen(answers = emptyList(), questionDisplayType = SMILEY) {
         // Do nothing
     }
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNpsQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNpsQuestionScreen.kt
@@ -45,36 +45,35 @@ fun SurveyNpsQuestionScreen(
                 top.linkTo(parent.top)
             }, horizontalArrangement = Arrangement.Center
         ) {
-            answers.forEachIndexed { index, surveyAnswer ->
-                if (index < MAX_NUMBER_OF_NPS_QUESTION) {
-                    val eachItemWidth = LocalDensity.current.run {
-                        (LocalConfiguration.current.screenWidthDp.dp - 40.dp) / MAX_NUMBER_OF_NPS_QUESTION
-                    }
-                    TextButton(
-                        onClick = {
-                            selectedIndex = index
-                            onChooseAnswer(answers.mapIndexed { index, surveyAnswer ->
-                                surveyAnswer.copy(selected = index == selectedIndex)
-                            })
-                        },
-                        border = BorderStroke(0.5.dp, Color.White),
-                        shape = RoundedCornerShape(
-                            topStart = if (index == START_INDEX) 10.dp else 0.dp,
-                            bottomStart = if (index == START_INDEX) 10.dp else 0.dp,
-                            topEnd = if (index == MAX_NUMBER_OF_NPS_QUESTION - 1) 10.dp else 0.dp,
-                            bottomEnd = if (index == MAX_NUMBER_OF_NPS_QUESTION - 1) 10.dp else 0.dp
-                        ),
-                        colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
-                        modifier = Modifier.size(eachItemWidth, 56.dp)
-                    ) {
-                        SurveyBoldText(
-                            text = surveyAnswer.text, color = if (index <= selectedIndex) {
-                                Color.White
-                            } else {
-                                White50
-                            }, fontSize = 20.sp, textAlign = TextAlign.Center
-                        )
-                    }
+            answers.take(MAX_NUMBER_OF_NPS_QUESTION)
+                .forEachIndexed { index, surveyAnswer ->
+                val eachItemWidth = LocalDensity.current.run {
+                    (LocalConfiguration.current.screenWidthDp.dp - 40.dp) / MAX_NUMBER_OF_NPS_QUESTION
+                }
+                TextButton(
+                    onClick = {
+                        selectedIndex = index
+                        onChooseAnswer(answers.mapIndexed { index, surveyAnswer ->
+                            surveyAnswer.copy(selected = index == selectedIndex)
+                        })
+                    },
+                    border = BorderStroke(0.5.dp, Color.White),
+                    shape = RoundedCornerShape(
+                        topStart = if (index == START_INDEX) 10.dp else 0.dp,
+                        bottomStart = if (index == START_INDEX) 10.dp else 0.dp,
+                        topEnd = if (index == MAX_NUMBER_OF_NPS_QUESTION - 1) 10.dp else 0.dp,
+                        bottomEnd = if (index == MAX_NUMBER_OF_NPS_QUESTION - 1) 10.dp else 0.dp
+                    ),
+                    colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
+                    modifier = Modifier.size(eachItemWidth, 56.dp)
+                ) {
+                    SurveyBoldText(
+                        text = surveyAnswer.text, color = if (index <= selectedIndex) {
+                            Color.White
+                        } else {
+                            White50
+                        }, fontSize = 20.sp, textAlign = TextAlign.Center
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNpsQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNpsQuestionScreen.kt
@@ -2,21 +2,22 @@ package com.kks.nimblesurveyjetpackcompose.ui.presentation.survey
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Surface
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,7 +32,7 @@ private const val START_INDEX = 0
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun SurveyNpsQuestion(
+fun SurveyNpsQuestionScreen(
     answers: List<SurveyAnswer>,
     onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit
 ) {
@@ -49,27 +50,28 @@ fun SurveyNpsQuestion(
             horizontalArrangement = Arrangement.Center
         ) {
             answers.forEachIndexed { index, surveyAnswer ->
-                Box(contentAlignment = Alignment.Center) {
-                    Surface(
-                        onClick = {
-                            selectedIndex = index
-                            onChooseAnswer(
-                                answers.mapIndexed { index, surveyAnswer ->
-                                    surveyAnswer.copy(selected = index == selectedIndex)
-                                }
-                            )
-                        },
-                        border = BorderStroke(0.5.dp, Color.White),
-                        shape = RoundedCornerShape(
-                            topStart = if (index == START_INDEX) 10.dp else 0.dp,
-                            bottomStart = if (index == START_INDEX) 10.dp else 0.dp,
-                            topEnd = if (index == answers.lastIndex) 10.dp else 0.dp,
-                            bottomEnd = if (index == answers.lastIndex) 10.dp else 0.dp
-                        ),
-                        color = Color.Transparent,
-                        modifier = Modifier.size(33.dp, 56.dp)
-                    ) { /* Do nothing */ }
-
+                val eachItemWidth = LocalDensity.current.run {
+                    (LocalConfiguration.current.screenWidthDp.dp - 40.dp) / answers.size
+                }
+                TextButton(
+                    onClick = {
+                        selectedIndex = index
+                        onChooseAnswer(
+                            answers.mapIndexed { index, surveyAnswer ->
+                                surveyAnswer.copy(selected = index == selectedIndex)
+                            }
+                        )
+                    },
+                    border = BorderStroke(0.5.dp, Color.White),
+                    shape = RoundedCornerShape(
+                        topStart = if (index == START_INDEX) 10.dp else 0.dp,
+                        bottomStart = if (index == START_INDEX) 10.dp else 0.dp,
+                        topEnd = if (index == answers.lastIndex) 10.dp else 0.dp,
+                        bottomEnd = if (index == answers.lastIndex) 10.dp else 0.dp
+                    ),
+                    colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
+                    modifier = Modifier.size(eachItemWidth,56.dp)
+                ) {
                     SurveyBoldText(
                         text = surveyAnswer.text,
                         color = if (index <= selectedIndex) {
@@ -106,7 +108,7 @@ fun SurveyNpsQuestion(
 @Preview(showBackground = true, backgroundColor = 0)
 @Composable
 fun PreviewSurveyNPSQuestion() {
-    SurveyNpsQuestion(answers = emptyList()) {
+    SurveyNpsQuestionScreen(answers = emptyList()) {
         // Do nothing
     }
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNpsQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyNpsQuestionScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -29,59 +28,53 @@ import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White50
 
 private const val START_INDEX = 0
+private const val MAX_NUMBER_OF_NPS_QUESTION = 10
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun SurveyNpsQuestionScreen(
-    answers: List<SurveyAnswer>,
-    onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit
+    answers: List<SurveyAnswer>, onChooseAnswer: (answers: List<SurveyAnswer>) -> Unit
 ) {
     var selectedIndex by remember { mutableStateOf(answers.indexOfFirst { it.selected }) }
 
     ConstraintLayout(modifier = Modifier.wrapContentWidth()) {
         val (nps, notAtAll, extremely) = createRefs()
         Row(
-            modifier = Modifier
-                .constrainAs(nps) {
-                    start.linkTo(parent.start, 20.dp)
-                    end.linkTo(parent.end, 20.dp)
-                    top.linkTo(parent.top)
-                },
-            horizontalArrangement = Arrangement.Center
+            modifier = Modifier.constrainAs(nps) {
+                start.linkTo(parent.start, 20.dp)
+                end.linkTo(parent.end, 20.dp)
+                top.linkTo(parent.top)
+            }, horizontalArrangement = Arrangement.Center
         ) {
             answers.forEachIndexed { index, surveyAnswer ->
-                val eachItemWidth = LocalDensity.current.run {
-                    (LocalConfiguration.current.screenWidthDp.dp - 40.dp) / answers.size
-                }
-                TextButton(
-                    onClick = {
-                        selectedIndex = index
-                        onChooseAnswer(
-                            answers.mapIndexed { index, surveyAnswer ->
+                if (index < MAX_NUMBER_OF_NPS_QUESTION) {
+                    val eachItemWidth = LocalDensity.current.run {
+                        (LocalConfiguration.current.screenWidthDp.dp - 40.dp) / MAX_NUMBER_OF_NPS_QUESTION
+                    }
+                    TextButton(
+                        onClick = {
+                            selectedIndex = index
+                            onChooseAnswer(answers.mapIndexed { index, surveyAnswer ->
                                 surveyAnswer.copy(selected = index == selectedIndex)
-                            }
-                        )
-                    },
-                    border = BorderStroke(0.5.dp, Color.White),
-                    shape = RoundedCornerShape(
-                        topStart = if (index == START_INDEX) 10.dp else 0.dp,
-                        bottomStart = if (index == START_INDEX) 10.dp else 0.dp,
-                        topEnd = if (index == answers.lastIndex) 10.dp else 0.dp,
-                        bottomEnd = if (index == answers.lastIndex) 10.dp else 0.dp
-                    ),
-                    colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
-                    modifier = Modifier.size(eachItemWidth,56.dp)
-                ) {
-                    SurveyBoldText(
-                        text = surveyAnswer.text,
-                        color = if (index <= selectedIndex) {
-                            Color.White
-                        } else {
-                            White50
+                            })
                         },
-                        fontSize = 20.sp,
-                        textAlign = TextAlign.Center
-                    )
+                        border = BorderStroke(0.5.dp, Color.White),
+                        shape = RoundedCornerShape(
+                            topStart = if (index == START_INDEX) 10.dp else 0.dp,
+                            bottomStart = if (index == START_INDEX) 10.dp else 0.dp,
+                            topEnd = if (index == MAX_NUMBER_OF_NPS_QUESTION - 1) 10.dp else 0.dp,
+                            bottomEnd = if (index == MAX_NUMBER_OF_NPS_QUESTION - 1) 10.dp else 0.dp
+                        ),
+                        colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
+                        modifier = Modifier.size(eachItemWidth, 56.dp)
+                    ) {
+                        SurveyBoldText(
+                            text = surveyAnswer.text, color = if (index <= selectedIndex) {
+                                Color.White
+                            } else {
+                                White50
+                            }, fontSize = 20.sp, textAlign = TextAlign.Center
+                        )
+                    }
                 }
             }
         }
@@ -94,14 +87,12 @@ fun SurveyNpsQuestionScreen(
             },
             color = White50
         )
-        SurveyBoldText(
-            text = stringResource(id = R.string.survey_question_extremely_likely),
+        SurveyBoldText(text = stringResource(id = R.string.survey_question_extremely_likely),
             fontSize = 17.sp,
             modifier = Modifier.constrainAs(extremely) {
                 top.linkTo(nps.bottom)
                 end.linkTo(nps.end)
-            }
-        )
+            })
     }
 }
 

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.sp
 import com.kks.nimblesurveyjetpackcompose.R
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.DROPDOWN
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.NONE
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.NPS
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.SMILEY
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.STARS
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.THUMBS
@@ -53,13 +54,16 @@ fun SurveyQuestionScreen(
         )
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             when (surveyQuestion.questionDisplayType) {
-                DROPDOWN -> SurveyDropDownQuestion(answers = surveyQuestion.answers) {
+                NPS -> SurveyNpsQuestionScreen(answers = surveyQuestion.answers) {
+                    onChooseAnswer(surveyQuestion.id, it)
+                }
+                DROPDOWN -> SurveyDropDownQuestionScreen(answers = surveyQuestion.answers) {
                     onChooseAnswer(surveyQuestion.id, it)
                 }
                 SMILEY,
                 STARS,
                 THUMBS -> if (surveyQuestion.answers.size >= NUMBER_OF_EMOJI_ANSWERS) {
-                    SurveyEmojiQuestion(
+                    SurveyEmojiQuestionScreen(
                         answers = surveyQuestion.answers,
                         questionDisplayType = surveyQuestion.questionDisplayType
                     ) {

--- a/app/src/test/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImplTest.kt
+++ b/app/src/test/java/com/kks/nimblesurveyjetpackcompose/repo/survey/SurveyRepoImplTest.kt
@@ -9,6 +9,7 @@ import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.DROPDOWN
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.THUMBS
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.SMILEY
 import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.STARS
+import com.kks.nimblesurveyjetpackcompose.model.QuestionDisplayType.NPS
 import com.kks.nimblesurveyjetpackcompose.model.ResourceState
 import com.kks.nimblesurveyjetpackcompose.model.request.SubmitSurveyRequest
 import com.kks.nimblesurveyjetpackcompose.model.response.BaseResponse
@@ -157,14 +158,29 @@ class SurveyRepoImplTest {
 
     @Test
     fun `When submitSurvey for Star question, answers with null is submitted`() = runTest {
-        val thumbsQuestion = surveyQuestion.copy(
+        val starQuestion = surveyQuestion.copy(
             questionDisplayType = STARS,
             answers = listOf(surveyAnswer.copy(selected = true))
         )
 
-        sut.submitSurvey(surveyId = "0", surveyQuestions = listOf(thumbsQuestion)).collect()
+        sut.submitSurvey(surveyId = "0", surveyQuestions = listOf(starQuestion)).collect()
 
-        val expected = thumbsQuestion.toSurveyQuestionRequest()
+        val expected = starQuestion.toSurveyQuestionRequest()
+        assertThat(expected.answers.first().answer).isNull()
+
+        coVerify { api.submitSurvey(SubmitSurveyRequest(surveyId = "0", questions = listOf(expected))) }
+    }
+
+    @Test
+    fun `When submitSurvey for NPS question, answers with null is submitted`() = runTest {
+        val npsQuestion = surveyQuestion.copy(
+            questionDisplayType = NPS,
+            answers = listOf(surveyAnswer.copy(selected = true))
+        )
+
+        sut.submitSurvey(surveyId = "0", surveyQuestions = listOf(npsQuestion)).collect()
+
+        val expected = npsQuestion.toSurveyQuestionRequest()
         assertThat(expected.answers.first().answer).isNull()
 
         coVerify { api.submitSurvey(SubmitSurveyRequest(surveyId = "0", questions = listOf(expected))) }


### PR DESCRIPTION
Closes #38 #39 

## What happened 👀

When a Question model has display_type as nps,

- Display an NPS scale in the Answer section
- The number of options (the scale range) must match with the number of the answers.
- By default, none are initially selected.

When tapping the Next button (or the Submit button) on n NPS question, store the currently selected option,
```
{
  "id": "{{question-id}}",
  "answers": [
    {
      "id": "{{selected-answer-id}}"
    }
  ]
}
```

## Insight 📝

- Add type for NPS
- Integrate with ui
- Since there are more than 10 answers, changed the ui to be more flexible by depending on the screen width

## Proof Of Work 📹


https://user-images.githubusercontent.com/32578035/193227028-b099232a-7f93-48c4-9495-a711ef5ffac2.mp4




