### PR TITLE
[#110] [Integrate] As a user I can see zoom in and zoom out animation in survey detail screen

### DIFF
--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/Extensions.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/Extensions.kt
@@ -1,0 +1,28 @@
+package com.kks.nimblesurveyjetpackcompose
+
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+
+// Reference https://medium.com/androiddevelopers/alternatives-to-idling-resources-in-compose-tests-8ae71f9fc473
+
+private const val WAIT_UNTIL_TIMEOUT = 1_000L
+
+fun ComposeContentTestRule.waitUntilNodeCount(
+    matcher: SemanticsMatcher,
+    count: Int,
+    timeoutMillis: Long = WAIT_UNTIL_TIMEOUT
+) {
+    waitUntil(timeoutMillis) {
+        onAllNodes(matcher).fetchSemanticsNodes().size == count
+    }
+}
+
+fun ComposeContentTestRule.waitUntilExists(
+    matcher: SemanticsMatcher,
+    timeoutMillis: Long = WAIT_UNTIL_TIMEOUT
+) = waitUntilNodeCount(matcher, 1, timeoutMillis)
+
+fun ComposeContentTestRule.waitUntilDoesNotExist(
+    matcher: SemanticsMatcher,
+    timeoutMillis: Long = WAIT_UNTIL_TIMEOUT
+) = waitUntilNodeCount(matcher, 0, timeoutMillis)

--- a/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/splash/SplashScreenTest.kt
+++ b/app/src/androidTest/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/splash/SplashScreenTest.kt
@@ -8,6 +8,7 @@ import com.kks.nimblesurveyjetpackcompose.repo.login.LoginRepo
 import com.kks.nimblesurveyjetpackcompose.ui.theme.NimbleSurveyJetpackComposeTheme
 import com.kks.nimblesurveyjetpackcompose.util.PreferenceManager
 import com.kks.nimblesurveyjetpackcompose.viewmodel.splash.SplashViewModel
+import com.kks.nimblesurveyjetpackcompose.waitUntilExists
 import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -168,5 +169,6 @@ class SplashScreenTest : BaseAndroidComposeTest() {
                 )
             }
         }
+        composeTestRule.waitUntilExists(hasText(getString(R.string.login_log_in_button)))
     }
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -24,7 +24,7 @@ enum class QuestionDisplayType(val typeValue: String, val isIdOnlyAnswer: Boolea
     THUMBS("thumbs", true),
     STARS("star", true),
     NPS("nps", true),
-    CHOICE("choice",true)
+    CHOICE("choice", true)
 }
 
 fun List<SurveyQuestion>.sortedByDisplayOrder(): List<SurveyQuestion> = this.sortedBy { it.displayOrder }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.kks.nimblesurveyjetpackcompose.ui.presentation.survey
 
+import android.os.CountDownTimer
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
@@ -32,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -95,9 +97,34 @@ fun SurveyDetailScreen(
     val isStartPage = currentPage == 0
     val isLastPage = currentPage == surveyQuestions.size
 
+    var scale by remember { mutableStateOf(1f) }
+
+    LaunchedEffect(key1 = Unit) {
+        object : CountDownTimer(500,25) {
+            override fun onTick(millisUntilFinished: Long) {
+                scale += 0.025f
+            }
+
+            override fun onFinish() {
+                scale = 1.5f
+            }
+        }.start()
+    }
+
+    val popBackAnimationTimer = object : CountDownTimer(500,25) {
+        override fun onTick(millisUntilFinished: Long) {
+            scale -= 0.025f
+        }
+
+        override fun onFinish() {
+            scale = 1f
+            navigator.popBackStack()
+        }
+    }
+
     BackHandler {
         if (currentPage > 0) showConfirmDialog = true
-        else navigator.popBackStack()
+        else popBackAnimationTimer.start()
     }
 
     LaunchedEffect(key1 = pagerState) {
@@ -114,7 +141,12 @@ fun SurveyDetailScreen(
         AsyncImage(
             model = survey.coverImageFullUrl,
             contentDescription = stringResource(id = R.string.survey_detail_background_image),
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale
+                ),
             placeholder = placeholderPainter,
             contentScale = ContentScale.Crop
         )
@@ -142,7 +174,7 @@ fun SurveyDetailScreen(
             }
         }
         SurveyToolbar(
-            navigator = navigator,
+            popBackAnimationTimer = popBackAnimationTimer,
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.TopStart)
@@ -168,7 +200,7 @@ fun SurveyDetailScreen(
                 .padding(bottom = 54.dp, end = 20.dp)
                 .semantics { contentDescription = startSurveyDescription }
         )
-        if (shouldShowThanks) LottieView(navigator = navigator)
+        if (shouldShowThanks) LottieView(popBackAnimationTimer = popBackAnimationTimer)
         NextQuestionButton(
             showButton = !isStartPage && !isLastPage,
             onNextSlide = {
@@ -188,7 +220,7 @@ fun SurveyDetailScreen(
                 negativeButtonText = stringResource(id = R.string.survey_question_warning_dialog_cancel),
                 onClickPositiveButton = {
                     showConfirmDialog = false
-                    navigator.popBackStack()
+                    popBackAnimationTimer.start()
                 },
                 onClickNegativeButton = { showConfirmDialog = false }
             )
@@ -206,7 +238,7 @@ fun SurveyDetailScreen(
 }
 
 @Composable
-fun LottieView(navigator: DestinationsNavigator) {
+fun LottieView(popBackAnimationTimer: CountDownTimer) {
     val retrySignal = rememberLottieRetrySignal()
     val composition by rememberLottieComposition(
         LottieCompositionSpec.Url(SUBMIT_SUCCESS_LOTTIE_URL),
@@ -217,7 +249,7 @@ fun LottieView(navigator: DestinationsNavigator) {
     )
     val progress by animateLottieCompositionAsState(composition)
 
-    if (progress == LOTTIE_ENDS) navigator.popBackStack()
+    if (progress == LOTTIE_ENDS) popBackAnimationTimer.start()
 
     Column(
         modifier = Modifier
@@ -349,7 +381,7 @@ fun SurveyBoldText(
 
 @Composable
 fun SurveyToolbar(
-    navigator: DestinationsNavigator,
+    popBackAnimationTimer: CountDownTimer,
     modifier: Modifier,
     showBack: Boolean,
     showClose: Boolean,
@@ -358,7 +390,7 @@ fun SurveyToolbar(
     Box(modifier = modifier) {
         if (showBack) {
             IconButton(
-                onClick = { navigator.popBackStack() },
+                onClick = { popBackAnimationTimer.start() },
                 modifier = Modifier.align(Alignment.CenterStart)
             ) {
                 Image(

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyDetailScreen.kt
@@ -76,6 +76,12 @@ private const val SUBMIT_SUCCESS_LOTTIE_URL = "https://assets2.lottiefiles.com/p
 private const val LOTTIE_ENDS = 1.0f
 private const val LOTTIE_FAIL_COUNT = 3
 
+private const val ZOOM_DURATION_IN_MILLIS = 500L
+private const val ZOOM_INTERVAL_IN_MILLIS = 25L
+private const val SCALE_PER_COUNTDOWN = 0.025f
+private const val ZOOMED_IN_SCALE = 1.5f
+private const val ORIGINAL_SCALE = 1f
+
 @OptIn(ExperimentalPagerApi::class)
 @Destination
 @Composable
@@ -100,24 +106,24 @@ fun SurveyDetailScreen(
     var scale by remember { mutableStateOf(1f) }
 
     LaunchedEffect(key1 = Unit) {
-        object : CountDownTimer(500,25) {
+        object : CountDownTimer(ZOOM_DURATION_IN_MILLIS, ZOOM_INTERVAL_IN_MILLIS) {
             override fun onTick(millisUntilFinished: Long) {
-                scale += 0.025f
+                scale += SCALE_PER_COUNTDOWN
             }
 
             override fun onFinish() {
-                scale = 1.5f
+                scale = ZOOMED_IN_SCALE
             }
         }.start()
     }
 
-    val popBackAnimationTimer = object : CountDownTimer(500,25) {
+    val popBackAnimationTimer = object : CountDownTimer(ZOOM_DURATION_IN_MILLIS, ZOOM_INTERVAL_IN_MILLIS) {
         override fun onTick(millisUntilFinished: Long) {
-            scale -= 0.025f
+            scale -= SCALE_PER_COUNTDOWN
         }
 
         override fun onFinish() {
-            scale = 1f
+            scale = ORIGINAL_SCALE
             navigator.popBackStack()
         }
     }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="transparent">#00000000</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,5 +3,6 @@
 
     <style name="Theme.NimbleSurveyJetpackCompose" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:statusBarColor">@color/purple_700</item>
+        <item name="android:windowBackground">@color/transparent</item>
     </style>
 </resources>


### PR DESCRIPTION
Closes #110 

## What happened 👀

According to Figma, navigating from survey screen to detail screen will zoom in the background image. When the user exit from the detail screen, background image will zoom out.

## Insight 📝

Tried zooming with `1f` and also `0.5f` per `25 milli seconds` but the animation seems to be lagging. So I tried using `0.025f` per `25 milli seconds` and animation becomes smoother.

## Proof Of Work 📹

https://user-images.githubusercontent.com/32578035/196386972-48d74194-f14f-439c-97c9-89810f8906a3.mp4



