### PR TITLE
[#47] [Integrate] As a user, I can see an outro question

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -19,6 +19,7 @@ enum class SurveyQuestionPickType {
 enum class QuestionDisplayType(val typeValue: String, val isIdOnlyAnswer: Boolean) {
     NONE("none", false),
     INTRO("intro", false),
+    OUTRO("outro", false),
     DROPDOWN("dropdown", true),
     SMILEY("smiley", true),
     THUMBS("thumbs", true),
@@ -40,6 +41,7 @@ fun SurveyQuestion.toSurveyQuestionRequest(): SurveyQuestionRequest =
 fun String.getQuestionDisplayType() =
     when (this) {
         QuestionDisplayType.INTRO.typeValue -> QuestionDisplayType.INTRO
+        QuestionDisplayType.OUTRO.typeValue -> QuestionDisplayType.OUTRO
         QuestionDisplayType.DROPDOWN.typeValue -> QuestionDisplayType.DROPDOWN
         QuestionDisplayType.SMILEY.typeValue -> QuestionDisplayType.SMILEY
         QuestionDisplayType.STARS.typeValue -> QuestionDisplayType.STARS


### PR DESCRIPTION
Closes #47 

## What happened 👀

Some surveys contain an intro question to show appreciation for users who take time on their surveys, or to guide them with a brief instructions. This type of question does not require any action apart from proceeding to the next question.

When a Question model has display_type as outro,

- Display a No-action Question
- Selecting the Next button skips to the next question (or submit the form if it's the last question of the survey)

## Insight 📝

Since the existing logic only shows the screens for which require a question screen, we only need to add the type value and the rest is the same.

## Proof Of Work 📹

https://user-images.githubusercontent.com/32578035/196378021-883aecb3-3876-4c4b-b226-1e2f3af3799a.mp4


