### PR TITLE
[#51] [#52] [UI] As a user, I can see a textfield question

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/SurveyTextField.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/SurveyTextField.kt
@@ -12,9 +12,11 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.kks.nimblesurveyjetpackcompose.ui.theme.NeuzeitFamily
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White40
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -35,6 +37,7 @@ fun SurveyTextField(
         onValueChange = { text ->
             onValueChange(text)
         },
+        textStyle = TextStyle.Default.copy(fontFamily = NeuzeitFamily),
         shape = RoundedCornerShape(10.dp),
         placeholder = {
             SurveyText(

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/SurveyTextField.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/SurveyTextField.kt
@@ -1,0 +1,62 @@
+package com.kks.nimblesurveyjetpackcompose.ui.presentation.common
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.kks.nimblesurveyjetpackcompose.ui.theme.White40
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun SurveyTextField(
+    value: String,
+    onValueChange: (text: String) -> Unit,
+    placeholderText: String,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = White40,
+    imeAction: ImeAction = ImeAction.Default
+) {
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    TextField(
+        value = value,
+        onValueChange = { text ->
+            onValueChange(text)
+        },
+        shape = RoundedCornerShape(10.dp),
+        placeholder = {
+            SurveyText(
+                text = placeholderText,
+                fontSize = 17.sp,
+                color = White40
+            )
+        },
+        colors = TextFieldDefaults.textFieldColors(
+            focusedIndicatorColor = Color.Transparent,
+            cursorColor = Color.White,
+            backgroundColor = backgroundColor,
+            disabledIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent
+        ),
+        keyboardActions = KeyboardActions(
+            onNext = { focusManager.moveFocus(FocusDirection.Down) },
+            onDone = { keyboardController?.hide() }
+        ),
+        keyboardOptions = KeyboardOptions(
+            imeAction = imeAction
+        ),
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/SurveyTextField.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/common/SurveyTextField.kt
@@ -34,9 +34,7 @@ fun SurveyTextField(
 
     TextField(
         value = value,
-        onValueChange = { text ->
-            onValueChange(text)
-        },
+        onValueChange = { text -> onValueChange(text) },
         textStyle = TextStyle.Default.copy(fontFamily = NeuzeitFamily),
         shape = RoundedCornerShape(10.dp),
         placeholder = {
@@ -57,9 +55,7 @@ fun SurveyTextField(
             onNext = { focusManager.moveFocus(FocusDirection.Down) },
             onDone = { keyboardController?.hide() }
         ),
-        keyboardOptions = KeyboardOptions(
-            imeAction = imeAction
-        ),
+        keyboardOptions = KeyboardOptions(imeAction = imeAction),
         modifier = modifier
     )
 }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextAreaQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextAreaQuestionScreen.kt
@@ -17,7 +17,7 @@ import com.kks.nimblesurveyjetpackcompose.ui.theme.White30
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White40
 import kotlinx.coroutines.delay
 
-private const val DELAY_VALUE_CHANGE_MILLI = 300L
+const val DELAY_VALUE_CHANGE_MILLI = 300L
 
 @Composable
 fun SurveyTextAreaQuestionScreen(

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextAreaQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextAreaQuestionScreen.kt
@@ -2,9 +2,6 @@ package com.kks.nimblesurveyjetpackcompose.ui.presentation.survey
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.TextField
-import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -12,13 +9,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
-import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.SurveyText
-import com.kks.nimblesurveyjetpackcompose.ui.theme.White20
+import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.SurveyTextField
+import com.kks.nimblesurveyjetpackcompose.ui.theme.White30
+import com.kks.nimblesurveyjetpackcompose.ui.theme.White40
 import kotlinx.coroutines.delay
 
 private const val DELAY_VALUE_CHANGE_MILLI = 300L
@@ -35,24 +31,11 @@ fun SurveyTextAreaQuestionScreen(
         onAnswerChange(answers.map { surveyAnswer -> surveyAnswer.copy(answer = answer, selected = true) })
     }
 
-    TextField(
+    SurveyTextField(
         value = answer,
         onValueChange = { answer = it },
-        shape = RoundedCornerShape(10.dp),
-        placeholder = {
-            SurveyText(
-                text = answers.firstOrNull()?.text.orEmpty(),
-                fontSize = 17.sp,
-                color = White20
-            )
-        },
-        colors = TextFieldDefaults.textFieldColors(
-            focusedIndicatorColor = Color.Transparent,
-            cursorColor = Color.White,
-            backgroundColor = White20,
-            disabledIndicatorColor = Color.Transparent,
-            unfocusedIndicatorColor = Color.Transparent
-        ),
+        placeholderText = answers.first().text,
+        backgroundColor = if (answer.isNotEmpty()) White40 else White30,
         modifier = Modifier
             .fillMaxWidth()
             .height(168.dp)

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextAreaQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextAreaQuestionScreen.kt
@@ -34,7 +34,7 @@ fun SurveyTextAreaQuestionScreen(
     SurveyTextField(
         value = answer,
         onValueChange = { answer = it },
-        placeholderText = answers.first().text,
+        placeholderText = answers.firstOrNull()?.text.orEmpty(),
         backgroundColor = if (answer.isNotEmpty()) White40 else White30,
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextFieldQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextFieldQuestionScreen.kt
@@ -4,29 +4,18 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.TextField
-import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
-import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.SurveyText
+import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.SurveyTextField
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White30
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White40
 import kotlinx.coroutines.delay
@@ -34,57 +23,31 @@ import kotlinx.coroutines.delay
 private const val TEXT_FIELD_HEIGHT = 56
 private const val SPACE_BETWEEN_TEXT_FIELDS = 16
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun SurveyTextFieldQuestionScreen(
     answers: List<SurveyAnswer>,
     onAnswerChange: (answers: List<SurveyAnswer>) -> Unit
 ) {
-    var answerStates by remember { mutableStateOf(answers.map { it.answer }) }
+    var answerState by remember { mutableStateOf(answers.map { it.answer }) }
     val heightOfQuestions = (TEXT_FIELD_HEIGHT * answers.size) + (SPACE_BETWEEN_TEXT_FIELDS * (answers.size - 1))
-    val focusManager = LocalFocusManager.current
-    val keyboardController = LocalSoftwareKeyboardController.current
 
-    LaunchedEffect(key1 = answerStates) {
+    LaunchedEffect(key1 = answerState) {
         delay(DELAY_VALUE_CHANE_MILLI)
         onAnswerChange(answers.mapIndexed { index, surveyAnswer ->
-            surveyAnswer.copy(answer = answerStates[index], selected = true)
+            surveyAnswer.copy(answer = answerState[index], selected = true)
         })
     }
 
     Column(verticalArrangement = Arrangement.SpaceBetween, modifier = Modifier.height(heightOfQuestions.dp)) {
         answers.forEachIndexed { index, surveyAnswer ->
-            TextField(
-                value = answerStates[index],
+            SurveyTextField(
+                value = answerState[index],
                 onValueChange = { text ->
-                    answerStates = answerStates.toMutableList().also { it[index] = text }
+                    answerState = answerState.toMutableList().also { it[index] = text }
                 },
-                shape = RoundedCornerShape(10.dp),
-                placeholder = {
-                    SurveyText(
-                        text = surveyAnswer.text,
-                        fontSize = 17.sp,
-                        color = White40
-                    )
-                },
-                colors = TextFieldDefaults.textFieldColors(
-                    focusedIndicatorColor = Color.Transparent,
-                    cursorColor = Color.White,
-                    backgroundColor = if (answerStates[index].isNotEmpty()) White40 else White30,
-                    disabledIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent
-                ),
-                keyboardActions = KeyboardActions(
-                    onNext = {
-                        focusManager.moveFocus(FocusDirection.Down)
-                    },
-                    onDone = {
-                        keyboardController?.hide()
-                    }
-                ),
-                keyboardOptions = KeyboardOptions(
-                    imeAction = if (index == answers.size - 1) ImeAction.Done else ImeAction.Next
-                ),
+                placeholderText = surveyAnswer.text,
+                backgroundColor = if (answerState[index].isNotEmpty()) White40 else White30,
+                imeAction = if (index == answers.lastIndex) ImeAction.Done else ImeAction.Next,
                 modifier = Modifier
                     .height(56.dp)
                     .fillMaxWidth()

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextFieldQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextFieldQuestionScreen.kt
@@ -1,0 +1,106 @@
+package com.kks.nimblesurveyjetpackcompose.ui.presentation.survey
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.kks.nimblesurveyjetpackcompose.model.SurveyAnswer
+import com.kks.nimblesurveyjetpackcompose.ui.presentation.common.SurveyText
+import com.kks.nimblesurveyjetpackcompose.ui.theme.White30
+import com.kks.nimblesurveyjetpackcompose.ui.theme.White40
+import kotlinx.coroutines.delay
+
+private const val TEXT_FIELD_HEIGHT = 56
+private const val SPACE_BETWEEN_TEXT_FIELDS = 16
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun SurveyTextFieldQuestionScreen(
+    answers: List<SurveyAnswer>,
+    onAnswerChange: (answers: List<SurveyAnswer>) -> Unit
+) {
+    var answerStates by remember { mutableStateOf(answers.map { it.answer }) }
+    val heightOfQuestions = (TEXT_FIELD_HEIGHT * answers.size) + (SPACE_BETWEEN_TEXT_FIELDS * (answers.size - 1))
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(key1 = answerStates) {
+        delay(DELAY_VALUE_CHANE_MILLI)
+        onAnswerChange(answers.mapIndexed { index, surveyAnswer ->
+            surveyAnswer.copy(answer = answerStates[index], selected = true)
+        })
+    }
+
+    Column(verticalArrangement = Arrangement.SpaceBetween, modifier = Modifier.height(heightOfQuestions.dp)) {
+        answers.forEachIndexed { index, surveyAnswer ->
+            TextField(
+                value = answerStates[index],
+                onValueChange = { text ->
+                    answerStates = answerStates.toMutableList().also { it[index] = text }
+                },
+                shape = RoundedCornerShape(10.dp),
+                placeholder = {
+                    SurveyText(
+                        text = surveyAnswer.text,
+                        fontSize = 17.sp,
+                        color = White40
+                    )
+                },
+                colors = TextFieldDefaults.textFieldColors(
+                    focusedIndicatorColor = Color.Transparent,
+                    cursorColor = Color.White,
+                    backgroundColor = if (answerStates[index].isNotEmpty()) White40 else White30,
+                    disabledIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent
+                ),
+                keyboardActions = KeyboardActions(
+                    onNext = {
+                        focusManager.moveFocus(FocusDirection.Down)
+                    },
+                    onDone = {
+                        keyboardController?.hide()
+                    }
+                ),
+                keyboardOptions = KeyboardOptions(
+                    imeAction = if (index == answers.size - 1) ImeAction.Done else ImeAction.Next
+                ),
+                modifier = Modifier
+                    .height(56.dp)
+                    .fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0)
+@Composable
+fun SurveyTextFieldQuestionScreenPreview() {
+    SurveyTextFieldQuestionScreen(
+        listOf(
+            SurveyAnswer("", "Your thought", 0, false),
+            SurveyAnswer("", "Your thought", 1, false)
+        )
+    ) {}
+}
+

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextFieldQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextFieldQuestionScreen.kt
@@ -28,7 +28,7 @@ fun SurveyTextFieldQuestionScreen(
     var answerState by remember { mutableStateOf(answers.map { it.answer }) }
 
     LaunchedEffect(key1 = answerState) {
-        delay(DELAY_VALUE_CHANE_MILLI)
+        delay(DELAY_VALUE_CHANGE_MILLI)
         onAnswerChange(answers.mapIndexed { index, surveyAnswer ->
             surveyAnswer.copy(answer = answerState[index], selected = true)
         })

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextFieldQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyTextFieldQuestionScreen.kt
@@ -20,16 +20,12 @@ import com.kks.nimblesurveyjetpackcompose.ui.theme.White30
 import com.kks.nimblesurveyjetpackcompose.ui.theme.White40
 import kotlinx.coroutines.delay
 
-private const val TEXT_FIELD_HEIGHT = 56
-private const val SPACE_BETWEEN_TEXT_FIELDS = 16
-
 @Composable
 fun SurveyTextFieldQuestionScreen(
     answers: List<SurveyAnswer>,
     onAnswerChange: (answers: List<SurveyAnswer>) -> Unit
 ) {
     var answerState by remember { mutableStateOf(answers.map { it.answer }) }
-    val heightOfQuestions = (TEXT_FIELD_HEIGHT * answers.size) + (SPACE_BETWEEN_TEXT_FIELDS * (answers.size - 1))
 
     LaunchedEffect(key1 = answerState) {
         delay(DELAY_VALUE_CHANE_MILLI)
@@ -38,7 +34,7 @@ fun SurveyTextFieldQuestionScreen(
         })
     }
 
-    Column(verticalArrangement = Arrangement.SpaceBetween, modifier = Modifier.height(heightOfQuestions.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
         answers.forEachIndexed { index, surveyAnswer ->
             SurveyTextField(
                 value = answerState[index],

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/theme/Color.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/theme/Color.kt
@@ -1,4 +1,5 @@
 @file:Suppress("MagicNumber")
+
 package com.kks.nimblesurveyjetpackcompose.ui.theme
 
 import androidx.compose.ui.graphics.Color
@@ -13,6 +14,7 @@ val CuriousBlue = Color(0xFF3D85C6)
 val White70 = Color(0xB3FFFFFF)
 val White20 = Color(0x33FFFFFF)
 val White30 = Color(0x4DFFFFFF)
+val White40 = Color(0x66FFFFFF)
 val White50 = Color(0x80FFFFFF)
 val BlackRussian = Color(0xff15151A)
 val Black60 = Color(0x99000000)


### PR DESCRIPTION
Closes #51 #52 

## What happened 👀

A textfield question is a question that allow users to answer with multiple short answers. There can be several textfields in a single textfield question. It is commonly used to ask for user's information.

**Example questions**
- _Don't miss out on our Exclusive Promotions!_
  - _Textfield 1: Name_
  - _Textfield 2: Email_
  - _Textfield 3: Mobile no._
  
- _Your contact information_
  - _Textfield 1: Name_
  - _Textfield 2: Room no._
  - _Textfield 3: Email address_
  - _Textfield 4: Phone_
  
## Insight 📝

- Implement ui for multiple text field questions
- Since the background color for text fields in the Figma are too transparent, I've change the color a bit
- Each text field can click `next` to go to the next question
- The last text filed will have `done` button to close the keyboard

## Proof Of Work 📹

https://user-images.githubusercontent.com/32578035/197175003-05794114-3a35-4d3d-90d9-239df16a2b23.mp4


