### PR TITLE
[#53] [#54] [Integrate] As a user, I can see and answer a textfield question

### DIFF
--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/model/SurveyQuestion.kt
@@ -26,7 +26,8 @@ enum class QuestionDisplayType(val typeValue: String, val isIdOnlyAnswer: Boolea
     STARS("star", true),
     NPS("nps", true),
     CHOICE("choice", true),
-    TEXTAREA("textarea", false)
+    TEXTAREA("textarea", false),
+    TEXTFIELD("textfield", false)
 }
 
 fun List<SurveyQuestion>.sortedByDisplayOrder(): List<SurveyQuestion> = this.sortedBy { it.displayOrder }
@@ -50,5 +51,6 @@ fun String.getQuestionDisplayType() =
         QuestionDisplayType.NPS.typeValue -> QuestionDisplayType.NPS
         QuestionDisplayType.CHOICE.typeValue -> QuestionDisplayType.CHOICE
         QuestionDisplayType.TEXTAREA.typeValue -> QuestionDisplayType.TEXTAREA
+        QuestionDisplayType.TEXTFIELD.typeValue -> QuestionDisplayType.TEXTFIELD
         else -> QuestionDisplayType.NONE
     }

--- a/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
+++ b/app/src/main/java/com/kks/nimblesurveyjetpackcompose/ui/presentation/survey/SurveyQuestionScreen.kt
@@ -71,6 +71,11 @@ fun SurveyQuestionScreen(
                         onChooseAnswer(surveyQuestion.id, it)
                     }
                 }
+                TEXTFIELD -> if (surveyQuestion.answers.isNotEmpty()) {
+                    SurveyTextFieldQuestionScreen(answers = surveyQuestion.answers) {
+                        onChooseAnswer(surveyQuestion.id, it)
+                    }
+                }
                 SMILEY,
                 STARS,
                 THUMBS -> if (surveyQuestion.answers.size >= NUMBER_OF_EMOJI_ANSWERS) {


### PR DESCRIPTION
\Closes #53 #54 

## What happened 👀

A textfield question is a question that allow users to answer with multiple short answers. There can be several textfields in a single textfield question. It is commonly used to ask for user's information.

**Example questions**
- _Don't miss out on our Exclusive Promotions!_
  - _Textfield 1: Name_
  - _Textfield 2: Email_
  - _Textfield 3: Mobile no._
  
- _Your contact information_
  - _Textfield 1: Name_
  - _Textfield 2: Room no._
  - _Textfield 3: Email address_
  - _Textfield 4: Phone_
  
## Insight 📝

- Logic to integrate textfield question is the same as text area question (which is already implemented)
- We only need to include the type value for `textfield` and the rest is the same

## Proof Of Work 📹


https://user-images.githubusercontent.com/32578035/197328033-703d7a0e-752e-44c3-afc6-ead0b0ee00d3.mp4


