### PR TITLE
[#135] Update build_pull_request to fix ruby issue

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -46,7 +46,7 @@ jobs:
         run: ./gradlew koverMergedXmlReport
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
 


### PR DESCRIPTION
- Closes #135 

## What happened 👀

Build pull request task is failing since current action is deprecated and not maintained anymore.

## Insight 📝

Change ruby setup.

## Proof Of Work 📹

TBD
